### PR TITLE
Improve law content excerpt to skip website boilerplate

### DIFF
--- a/src/components/modules/LawBrowser.jsx
+++ b/src/components/modules/LawBrowser.jsx
@@ -332,8 +332,7 @@ export function LawBrowser({ onBack }) {
                     {(selectedLaw.content?.full_text || selectedLaw.content?.text) ? (
                       <div className="bg-gray-50 dark:bg-whs-dark-700 rounded-xl p-4 text-sm text-gray-700 dark:text-gray-300 leading-relaxed whitespace-pre-wrap max-h-48 overflow-y-auto">
                         {highlightText(
-                          getLawExcerpt(selectedLaw, searchTerm, 500) ||
-                          (selectedLaw.content?.text?.substring(0, 500) + '...'),
+                          getLawExcerpt(selectedLaw, searchTerm, 800),
                           searchTerm
                         )}
                       </div>


### PR DESCRIPTION
- Update getLawExcerpt to intelligently find meaningful content
- Skip past navigation, disclaimers, and metadata boilerplate
- Look for content markers like § sections, articles, definitions
- Increase excerpt length to 800 chars for better context
- Try to end excerpts at sentence boundaries