### PR TITLE
Optimize build cache download performance

### DIFF
--- a/src/services/euLawsDatabase.js
+++ b/src/services/euLawsDatabase.js
@@ -5,9 +5,9 @@
  */
 
 // Import the full EU laws databases
-import atLawsData from '../../eu_safety_laws/at/at_safety_laws_database.json'
+import atLawsData from '../../eu_safety_laws/at/at_database.json'
 import deLawsData from '../../eu_safety_laws/de/de_safety_laws_database.json'
-import nlLawsData from '../../eu_safety_laws/nl/nl_safety_laws_database.json'
+import nlLawsData from '../../eu_safety_laws/nl/nl_database.json'
 
 // Database cache
 let lawsDatabase = null


### PR DESCRIPTION
The AT and NL safety laws database files were renamed from *_safety_laws_database.json to *_database.json but the imports in euLawsDatabase.js were not updated, causing the Netlify build to fail with "Could not resolve" errors.