### PR TITLE
Fix full text search and move compare to law items

### DIFF
--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -109,6 +109,7 @@ export const SearchInput = forwardRef(({
   onSearch,
   onClear,
   value,
+  onChange,
   placeholder = 'Search...',
   className = '',
   ...props
@@ -140,7 +141,7 @@ export const SearchInput = forwardRef(({
         value={currentValue}
         onChange={(e) => {
           setInternalValue(e.target.value)
-          props.onChange?.(e)
+          onChange?.(e)
         }}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}


### PR DESCRIPTION
- Fix SearchInput onChange handler being overridden by spread props
- Explicitly destructure onChange to ensure it's called properly
- Move compare buttons from law header to each law item in sidebar
- Each law now has "Compare All" (3 countries) and "Compare" (2 countries) buttons
- Update compare handlers to accept law parameter directly for async state handling