### PR TITLE
Fix language and framework selectors not persisting changes

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -95,13 +95,16 @@ export function Header() {
   const currentLanguage = languages.find(l => l.code === language) || languages[0]
 
   const handleFrameworkChange = (newFramework) => {
-    setFramework(newFramework)
+    // Save directly to localStorage before reload
+    localStorage.setItem('whs_framework', newFramework)
     setShowFrameworkMenu(false)
-    // Force a page reload to ensure all data is refreshed
+    // Reload to ensure all data is refreshed with new framework
     window.location.reload()
   }
 
   const handleLanguageChange = (newLanguage) => {
+    // Save directly to localStorage
+    localStorage.setItem('whs_language', newLanguage)
     setLanguage(newLanguage)
     setShowLanguageMenu(false)
   }


### PR DESCRIPTION
- Save directly to localStorage before calling setFramework/setLanguage
- For framework change: save to localStorage first, then reload
- For language change: save to localStorage first, then update React state

The previous approach relied on React useEffect to persist changes, but window.location.reload() was called before the effect could run.