### PR TITLE
Fix NL law scraper incomplete data

### DIFF
--- a/eu_safety_laws/nl/nl_database.json
+++ b/eu_safety_laws/nl/nl_database.json
@@ -1,13 +1,13 @@
 {
   "metadata": {
     "country": "NL",
-    "generated_at": "2025-12-14T17:06:32.319861",
+    "generated_at": "2025-12-17T19:56:22.593640",
     "document_count": 1,
     "error_count": 0
   },
   "documents": [
     {
-      "id": "cf6b6319665f152f",
+      "id": "1109c95c13f4bdbd",
       "version": "1.0.0",
       "type": "law",
       "jurisdiction": "NL",
@@ -23,60 +23,60 @@
         "robots_txt_compliant": true
       },
       "scraping": {
-        "scraped_at": "2025-12-14T17:06:31.818279",
-        "scraper_version": "7.0.0"
+        "scraped_at": "2025-12-17T19:56:22.092334",
+        "scraper_version": "7.1.0"
       },
       "whs_summary": {
-        "total_sections": 72,
+        "total_sections": 47,
         "logistics_relevance_distribution": {
-          "critical": 0,
-          "high": 0,
-          "medium": 10,
-          "low": 62
+          "critical": 5,
+          "high": 4,
+          "medium": 25,
+          "low": 13
         },
         "top_whs_topics": [
           [
-            "employee_rights",
-            8
-          ],
-          [
-            "penalties",
-            6
-          ],
-          [
-            "prevention_services",
-            5
-          ],
-          [
             "employer_obligations",
-            4
+            32
           ],
           [
-            "risk_assessment",
-            3
+            "employee_rights",
+            24
           ],
           [
             "workplace_design",
-            2
+            20
           ],
           [
-            "incident_reporting",
-            2
+            "risk_assessment",
+            12
           ],
           [
-            "hazardous_substances",
-            1
+            "prevention_services",
+            10
           ],
           [
-            "training",
-            1
+            "penalties",
+            10
+          ],
+          [
+            "ppe",
+            9
           ],
           [
             "documentation",
-            1
+            8
+          ],
+          [
+            "incident_reporting",
+            7
+          ],
+          [
+            "health_surveillance",
+            7
           ]
         ],
-        "critical_sections_count": 0
+        "critical_sections_count": 9
       },
       "chapters": [
         {
@@ -89,13 +89,39 @@
               "id": "08afb51d10e71ce0",
               "number": "1",
               "title": "Artikel 1. Definities",
-              "text": "... Sla het regelingonderdeel op\n\n[Wijziging(en) zonder datum inwerkingtreding aanwezig. Zie het wijzigingenoverzicht .]",
-              "whs_topics": [],
+              "text": "1 In deze wet en de daarop berustende bepalingen wordt verstaan onder: arbeidsmiddelen: alle op de arbeidsplaats gebruikte machines en verwante producten, installaties, apparaten, gereedschappen, digitale systemen en andere hulpmiddelen om de arbeid te verrichten; arbeidsongeval: een aan een werknemer in verband met het verrichten van arbeid overkomen ongewilde, plotselinge gebeurtenis, die schade aan de gezondheid tot vrijwel onmiddellijk gevolg heeft gehad en heeft geleid tot ziekteverzuim, of de dood tot vrijwel onmiddellijk gevolg heeft gehad; arbeidsplaats: iedere plaats die in verband met het verrichten van arbeid wordt of pleegt te worden gebruikt; arbodienst: een dienst als bedoeld in artikel 14a, tweede en derde lid ; ondernemingsraad: de ondernemingsraad, bedoeld in de Wet op de ondernemingsraden ; Onze Minister: Onze Minister van Sociale Zaken en Werkgelegenheid; personeelsvertegenwoordiging: de personeelsvertegenwoordiging, bedoeld in de Wet op de ondernemingsraden ; psychosociale arbeidsbelasting: de blootstelling aan factoren in de arbeidssituatie die stress teweeg brengen, waaronder in ieder geval: a. agressie of geweld; b. direct of indirect onderscheid; c. pesten; d. seksuele intimidatie; e. werkdruk; stress: een toestand die als negatief ervaren lichamelijke, psychische of sociale gevolgen heeft; toezichthouder: de toezichthouder, bedoeld in de Algemene wet bestuursrecht , en als zodanig aangewezen op grond van artikel 24 ; vrijwilliger: de persoon, die niet bij wijze van beroep arbeid verricht voor een privaatrechtelijk of publiekrechtelijk lichaam dat niet is onderworpen aan de vennootschapsbelasting dan wel voor een sportorganisatie en die geen werknemer is in de zin van artikel 2 van de Wet op de loonbelasting 1964 , met uitzondering van de persoon die arbeid verricht: a. ter voorbereiding op beroepsmatige arbeid; b. in het kader van een taakstraf dan wel in het kader van het voldoen aan voorwaarden ter voorkoming van strafvervolging als bedoeld in artikel 74, tweede lid, onderdeel f , of artikel 77f, eerste lid, onderdeel b, van het Wetboek van Strafrecht dan wel in het kader van deelneming aan een project als bedoeld in artikel 77e van het Wetboek van Strafrecht ; of c. als bedoeld in artikel 16, zesde lid, onderdeel c ; werkgever: a. degene jegens wie een ander krachtens arbeidsovereenkomst of publiekrechtelijke aanstelling gehouden is tot het verrichten van arbeid, behalve indien die ander aan een derde ter beschikking wordt gesteld voor het verrichten van arbeid, welke die derde gewoonlijk doet verrichten; of b. degene aan wie een ander ter beschikking wordt gesteld voor het verrichten van arbeid als bedoeld onder a; werknemer: de ander, genoemd in de begripsomschrijving van werkgever; zelfstandige: degene die zonder werkgever of werknemer te zijn arbeid verricht.\n1 In deze wet en de daarop berustende bepalingen wordt verstaan onder:\narbeidsmiddelen: alle op de arbeidsplaats gebruikte machines en verwante producten, installaties, apparaten, gereedschappen, digitale systemen en andere hulpmiddelen om de arbeid te verrichten;\narbeidsongeval: een aan een werknemer in verband met het verrichten van arbeid overkomen ongewilde, plotselinge gebeurtenis, die schade aan de gezondheid tot vrijwel onmiddellijk gevolg heeft gehad en heeft geleid tot ziekteverzuim, of de dood tot vrijwel onmiddellijk gevolg heeft gehad;\narbeidsplaats: iedere plaats die in verband met het verrichten van arbeid wordt of pleegt te worden gebruikt;\narbodienst: een dienst als bedoeld in artikel 14a, tweede en derde lid ;\nondernemingsraad: de ondernemingsraad, bedoeld in de Wet op de ondernemingsraden ;\nOnze Minister: Onze Minister van Sociale Zaken en Werkgelegenheid;\npersoneelsvertegenwoordiging: de personeelsvertegenwoordiging, bedoeld in de Wet op de ondernemingsraden ;\npsychosociale arbeidsbelasting: de blootstelling aan factoren in de arbeidssituatie die stress teweeg brengen, waaronder in ieder geval: a. agressie of geweld; b. direct of indirect onderscheid; c. pesten; d. seksuele intimidatie; e. werkdruk;\na. agressie of geweld;\nb. direct of indirect onderscheid;\nd. seksuele intimidatie;\ne. werkdruk;\nstress: een toestand die als negatief ervaren lichamelijke, psychische of sociale gevolgen heeft;\ntoezichthouder: de toezichthouder, bedoeld in de Algemene wet bestuursrecht , en als zodanig aangewezen op grond van artikel 24 ;\nvrijwilliger: de persoon, die niet bij wijze van beroep arbeid verricht voor een privaatrechtelijk of publiekrechtelijk lichaam dat niet is onderworpen aan de vennootschapsbelasting dan wel voor een sportorganisatie en die geen werknemer is in de zin van artikel 2 van de Wet op de loonbelasting 1964 , met uitzondering van de persoon die arbeid verricht: a. ter voorbereiding op beroepsmatige arbeid; b. in het kader van een taakstraf dan wel in het kader van het voldoen aan voorwaarden ter voorkoming van strafvervolging als bedoeld in artikel 74, tweede lid, onderdeel f , of artikel 77f, eerste lid, onderdeel b, van het Wetboek van Strafrecht dan wel in het kader van deelneming aan een project als bedoeld in artikel 77e van het Wetboek van Strafrecht ; of c. als bedoeld in artikel 16, zesde lid, onderdeel c ;\na. ter voorbereiding op beroepsmatige arbeid;\nb. in het kader van een taakstraf dan wel in het kader van het voldoen aan voorwaarden ter voorkoming van strafvervolging als bedoeld in artikel 74, tweede lid, onderdeel f , of artikel 77f, eerste lid, onderdeel b, van het Wetboek van Strafrecht dan wel in het kader van deelneming aan een project als bedoeld in artikel 77e van het Wetboek van Strafrecht ; of\nc. als bedoeld in artikel 16, zesde lid, onderdeel c ;\nwerkgever: a. degene jegens wie een ander krachtens arbeidsovereenkomst of publiekrechtelijke aanstelling gehouden is tot het verrichten van arbeid, behalve indien die ander aan een derde ter beschikking wordt gesteld voor het verrichten van arbeid, welke die derde gewoonlijk doet verrichten; of b. degene aan wie een ander ter beschikking wordt gesteld voor het verrichten van arbeid als bedoeld onder a;\na. degene jegens wie een ander krachtens arbeidsovereenkomst of publiekrechtelijke aanstelling gehouden is tot het verrichten van arbeid, behalve indien die ander aan een derde ter beschikking wordt gesteld voor het verrichten van arbeid, welke die derde gewoonlijk doet verrichten; of\nb. degene aan wie een ander ter beschikking wordt gesteld voor het verrichten van arbeid als bedoeld onder a;\nwerknemer: de ander, genoemd in de begripsomschrijving van werkgever;\nzelfstandige: degene die zonder werkgever of werknemer te zijn arbeid verricht.\n2 In deze wet en de daarop berustende bepalingen wordt mede verstaan onder: bedrijf: een andere plaats waar arbeid wordt verricht of pleegt te worden verricht; inrichting: een andere plaats waar arbeid wordt verricht op pleegt te worden verricht; werkgever: a. degene die zonder werkgever of werknemer in de zin van het eerste lid te zijn, een ander onder zijn gezag arbeid doet verrichten; of b. degene die zonder werkgever of werknemer in de zin van het eerste lid te zijn, een ander niet onder zijn gezag arbeid in een woning doet verrichten, in bij algemene maatregel van bestuur aan te wijzen gevallen; werknemer: de ander, genoemd in de in dit lid opgenomen begripsomschrijving van werkgever, met uitzondering van degene die als vrijwilliger arbeid verricht.\n2 In deze wet en de daarop berustende bepalingen wordt mede verstaan onder:\nbedrijf: een andere plaats waar arbeid wordt verricht of pleegt te worden verricht;\ninrichting: een andere plaats waar arbeid wordt verricht op pleegt te worden verricht;\nwerkgever: a. degene die zonder werkgever of werknemer in de zin van het eerste lid te zijn, een ander onder zijn gezag arbeid doet verrichten; of b. degene die zonder werkgever of werknemer in de zin van het eerste lid te zijn, een ander niet onder zijn gezag arbeid in een woning doet verrichten, in bij algemene maatregel van bestuur aan te wijzen gevallen;\na. degene die zonder werkgever of werknemer in de zin van het eerste lid te zijn, een ander onder zijn gezag arbeid doet verrichten; of\nb. degene die zonder werkgever of werknemer in de zin van het eerste lid te zijn, een ander niet onder zijn gezag arbeid in een woning doet verrichten, in bij algemene maatregel van bestuur aan te wijzen gevallen;\nwerknemer: de ander, genoemd in de in dit lid opgenomen begripsomschrijving van werkgever, met uitzondering van degene die als vrijwilliger arbeid verricht.",
+              "whs_topics": [
+                {
+                  "id": "work_equipment",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 2
+                },
+                {
+                  "id": "ergonomics",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "incident_reporting",
+                  "relevance": "high",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "score": 7,
+                "level": "critical",
+                "high_keyword_matches": 2,
+                "medium_keyword_matches": 3
               },
               "paragraphs": []
             },
@@ -103,8 +129,24 @@
               "id": "63ab439bd85dfe72",
               "number": "2",
               "title": "Artikel 2. Uitbreiding Toepassingsgebied",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "Deze wet en de daarop berustende bepalingen zijn mede van toepassing op:\na. arbeid verricht binnen de exclusieve economische zone;\nb. verrichtingen van leerlingen en studenten in onderwijsinrichtingen of gedeelten daarvan, open ruimten daaronder begrepen, die vergelijkbaar zijn met arbeid in de beroepspraktijk;\nc. arbeid die geheel of ten dele buiten Nederland wordt verricht door personen, werkzaam aan boord van zeeschepen die op grond van voor Nederland geldende rechtsregels gerechtigd zijn de vlag van het Koninkrijk te voeren;\nd. arbeid die voor een in Nederland gevestigde werkgever geheel of ten dele buiten Nederland wordt verricht door personen, werkzaam aan boord van luchtvaartuigen.",
+              "whs_topics": [
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
                 "score": 0,
                 "level": "low",
@@ -125,13 +167,39 @@
               "id": "12b1c0f3ebcc7586",
               "number": "3",
               "title": "Artikel 3. Arbobeleid",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "1 De werkgever zorgt voor de veiligheid en de gezondheid van de werknemers inzake alle met de arbeid verbonden aspecten en voert daartoe een beleid dat is gericht op zo goed mogelijke arbeidsomstandigheden, waarbij hij, gelet op de stand van de wetenschap en professionele dienstverlening, het volgende in acht neemt: a. tenzij dit redelijkerwijs niet kan worden gevergd organiseert de werkgever de arbeid zodanig dat daarvan geen nadelige invloed uitgaat op de veiligheid en de gezondheid van de werknemer; b. tenzij dit redelijkerwijs niet kan worden gevergd worden de gevaren en risico's voor de veiligheid of de gezondheid van de werknemer zoveel mogelijk in eerste aanleg bij de bron daarvan voorkomen of beperkt; naar de mate waarin dergelijke gevaren en risico's niet bij de bron kunnen worden voorkomen of beperkt, worden daartoe andere doeltreffende maatregelen getroffen waarbij maatregelen gericht op collectieve bescherming voorrang hebben boven maatregelen gericht op individuele bescherming; slechts indien redelijkerwijs niet kan worden gevergd dat maatregelen worden getroffen die zijn gericht op individuele bescherming, worden doeltreffende en passende persoonlijke beschermingsmiddelen aan de werknemer ter beschikking gesteld; c. de inrichting van de arbeidsplaatsen, de werkmethoden en de bij de arbeid gebruikte arbeidsmiddelen alsmede de arbeidsinhoud worden zoveel als redelijkerwijs kan worden gevergd aan de persoonlijke eigenschappen van werknemers aangepast; d. monotone en tempogebonden arbeid wordt, zoveel als redelijkerwijs kan worden gevergd, vermeden dan wel, indien dat niet mogelijk is, beperkt; e. doeltreffende maatregelen worden getroffen op het gebied van de eerste hulp bij ongevallen, de brandbestrijding en de evacuatie van werknemers en andere aanwezige personen, en doeltreffende verbindingen worden onderhouden met de desbetreffende externe hulpverleningsorganisaties; f. elke werknemer moet bij ernstig en onmiddellijk gevaar voor zijn eigen veiligheid of die van anderen, rekening houdend met zijn technische kennis en middelen, de nodige passende maatregelen kunnen nemen om de gevolgen van een dergelijk gevaar te voorkomen, waarbij artikel 29, eerste lid, derde zin , van overeenkomstige toepassing is.\na. tenzij dit redelijkerwijs niet kan worden gevergd organiseert de werkgever de arbeid zodanig dat daarvan geen nadelige invloed uitgaat op de veiligheid en de gezondheid van de werknemer;\nb. tenzij dit redelijkerwijs niet kan worden gevergd worden de gevaren en risico's voor de veiligheid of de gezondheid van de werknemer zoveel mogelijk in eerste aanleg bij de bron daarvan voorkomen of beperkt; naar de mate waarin dergelijke gevaren en risico's niet bij de bron kunnen worden voorkomen of beperkt, worden daartoe andere doeltreffende maatregelen getroffen waarbij maatregelen gericht op collectieve bescherming voorrang hebben boven maatregelen gericht op individuele bescherming; slechts indien redelijkerwijs niet kan worden gevergd dat maatregelen worden getroffen die zijn gericht op individuele bescherming, worden doeltreffende en passende persoonlijke beschermingsmiddelen aan de werknemer ter beschikking gesteld;\nc. de inrichting van de arbeidsplaatsen, de werkmethoden en de bij de arbeid gebruikte arbeidsmiddelen alsmede de arbeidsinhoud worden zoveel als redelijkerwijs kan worden gevergd aan de persoonlijke eigenschappen van werknemers aangepast;\nd. monotone en tempogebonden arbeid wordt, zoveel als redelijkerwijs kan worden gevergd, vermeden dan wel, indien dat niet mogelijk is, beperkt;\ne. doeltreffende maatregelen worden getroffen op het gebied van de eerste hulp bij ongevallen, de brandbestrijding en de evacuatie van werknemers en andere aanwezige personen, en doeltreffende verbindingen worden onderhouden met de desbetreffende externe hulpverleningsorganisaties;\nf. elke werknemer moet bij ernstig en onmiddellijk gevaar voor zijn eigen veiligheid of die van anderen, rekening houdend met zijn technische kennis en middelen, de nodige passende maatregelen kunnen nemen om de gevolgen van een dergelijk gevaar te voorkomen, waarbij artikel 29, eerste lid, derde zin , van overeenkomstige toepassing is.\n2 De werkgever voert, binnen het algemeen arbeidsomstandighedenbeleid, een beleid gericht op voorkoming en indien dat niet mogelijk is beperking van psychosociale arbeidsbelasting.\n3 Ter uitvoering van het eerste lid draagt de werkgever zorg voor een goede verdeling van bevoegdheden en verantwoordelijkheden tussen de bij de werkgever werkzame personen, waarbij hij rekening houdt met de bekwaamheden van de werknemers.\n4 De werkgever toetst het arbeidsomstandighedenbeleid regelmatig aan de ervaringen die daarmee zijn opgedaan en past de maatregelen aan zo dikwijls als de daarmee opgedane ervaring daartoe aanleiding geeft.",
+              "whs_topics": [
+                {
+                  "id": "ppe",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "risk_assessment",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "first_aid",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "work_equipment",
+                  "relevance": "high",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "score": 8,
+                "level": "critical",
+                "high_keyword_matches": 2,
+                "medium_keyword_matches": 4
               },
               "paragraphs": []
             },
@@ -139,10 +207,20 @@
               "id": "9945ed266a328c69",
               "number": "4",
               "title": "Artikel 4. Aanpassing arbeidsplaats werknemer met structurele functionele beperking",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 In aanvulling op artikel 3, eerste lid, aanhef en onder c , past de werkgever, bedoeld in onderdeel a van de begripsomschrijving van werkgever in artikel 1, eerste lid , uit hoofde van de uitoefening van zijn taak, bedoeld in artikel 7:658a van het Burgerlijk Wetboek en artikel 76e van de Ziektewet , a. de inrichting van de arbeidsplaats, de werkmethoden en de bij de arbeid gebruikte arbeidsmiddelen, alsmede de arbeidsinhoud aan zijn werknemer, die in verband met ongeschiktheid ten gevolge van ziekte verhinderd is de bedongen arbeid te verrichten aan, en b. de inrichting van het bedrijf aan die werknemer aan, voorzover de behoefte daaraan wordt opgeroepen door de deelneming van die werknemer aan de werkzaamheden of het daarmee samenhangende verblijf in het bedrijf.\na. de inrichting van de arbeidsplaats, de werkmethoden en de bij de arbeid gebruikte arbeidsmiddelen, alsmede de arbeidsinhoud aan zijn werknemer, die in verband met ongeschiktheid ten gevolge van ziekte verhinderd is de bedongen arbeid te verrichten aan, en\nb. de inrichting van het bedrijf aan die werknemer aan, voorzover de behoefte daaraan wordt opgeroepen door de deelneming van die werknemer aan de werkzaamheden of het daarmee samenhangende verblijf in het bedrijf.\n2 Het eerste lid is van overeenkomstige toepassing op de eigenrisicodrager, bedoeld in artikel 1, eerste lid, onderdeel h, van de Ziektewet en de persoon, bedoeld in artikel 29, tweede lid, onderdelen a, b en c, van die wet , die laatstelijk tot de eigenrisicodrager in dienstbetrekking stond, gedurende de periode dat de eigenrisicodrager aan die persoon ziekengeld moet betalen.",
               "whs_topics": [
                 {
                   "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "work_equipment",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employer_obligations",
                   "relevance": "high",
                   "match_count": 1
                 },
@@ -153,10 +231,10 @@
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
+                "score": 2,
+                "level": "medium",
                 "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "medium_keyword_matches": 2
               },
               "paragraphs": []
             },
@@ -164,10 +242,30 @@
               "id": "cf1b258f4dc74bf7",
               "number": "5",
               "title": "Artikel 5. Inventarisatie en evaluatie van risico’s",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 Bij het voeren van het arbeidsomstandighedenbeleid legt de werkgever in een inventarisatie en evaluatie schriftelijk vast welke risico's de arbeid voor de werknemers met zich brengt. Deze risico-inventarisatie en -evaluatie bevat tevens een beschrijving van de gevaren en de risico-beperkende maatregelen en de risico's voor bijzondere categorieën van werknemers.\n2 In de risico-inventarisatie en -evaluatie wordt aandacht besteed aan de toegang van werknemers tot een deskundige werknemer of persoon, bedoeld in de artikelen 13 en 14 , of de arbodienst.\n3 Een plan van aanpak, waarin is aangegeven welke maatregelen zullen worden genomen in verband met de bedoelde risico's en de samenhang daartussen, een en ander overeenkomstig artikel 3 , maakt deel uit van de risico-inventarisatie en -evaluatie. In het plan van aanpak wordt tevens aangegeven binnen welke termijn deze maatregelen zullen worden genomen.\n4 De risico-inventarisatie en -evaluatie wordt aangepast zo dikwijls als de daarmee opgedane ervaring, gewijzigde werkmethoden of werkomstandigheden of de stand van de wetenschap en professionele dienstverlening daartoe aanleiding geven.\n5 Indien de werkgever arbeid doet verrichten door een werknemer die hem ter beschikking wordt gesteld, verstrekt hij tijdig voor de aanvang van de werkzaamheden aan degene, die de werknemer ter beschikking stelt, de beschrijving uit de risico-inventarisatie en -evaluatie van de gevaren en risicobeperkende maatregelen en van de risico's voor de werknemer op de in te nemen arbeidsplaats, opdat diegene deze beschrijving verstrekt aan de betrokken werknemer.\n6 De werkgever zorgt ervoor dat iedere werknemer kennis kan nemen van de risico-inventarisatie en -evaluatie.",
               "whs_topics": [
                 {
                   "id": "risk_assessment",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "documentation",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "prevention_services",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "employer_obligations",
                   "relevance": "high",
                   "match_count": 1
                 }
@@ -184,8 +282,23 @@
               "id": "f5ef61eb05d2342d",
               "number": "6",
               "title": "Artikel 6. Voorkoming en beperking van zware ongevallen waarbij gevaarlijke stoffen",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 De werkgever neemt bij het voeren van het arbeidsomstandighedenbeleid de maatregelen die nodig zijn ter voorkoming en beperking van zware ongevallen waarbij gevaarlijke stoffen zijn betrokken en de gevolgen daarvan voor de veiligheid en de gezondheid van de in het bedrijf, de inrichting, of een deel daarvan werkzame werknemers. Bij of krachtens algemene maatregel van bestuur worden regels gesteld met betrekking tot: a. de categorieën van bedrijven, inrichtingen of delen daarvan ten aanzien waarvan de werkgever die maatregelen neemt; b. de gegevens die de werkgever met betrekking tot de bedrijven, inrichtingen of delen daarvan, bedoeld onder a, op schrift stelt of verstrekt aan de toezichthouder of aan de werknemers en de andere deskundige personen, bedoeld in artikel 13, eerste tot en met derde lid , de personen, bedoeld in artikel 14, eerste lid en de arbodienst; c. de maatregelen die de werkgever neemt ten aanzien van de bedrijven, inrichtingen of delen daarvan, bedoeld onder a; d. het tijdstip waarop en de frequentie waarmee wordt voldaan aan de verplichtingen, bedoeld onder b en c; e. een verbod op de exploitatie van het bedrijf, de inrichting of een deel daarvan, indien niet of niet voldoende is voldaan aan een of meer verplichtingen krachtens dit artikel; f. het toezicht op de naleving van het bij of krachtens dit artikel bepaalde.\na. de categorieën van bedrijven, inrichtingen of delen daarvan ten aanzien waarvan de werkgever die maatregelen neemt;\nb. de gegevens die de werkgever met betrekking tot de bedrijven, inrichtingen of delen daarvan, bedoeld onder a, op schrift stelt of verstrekt aan de toezichthouder of aan de werknemers en de andere deskundige personen, bedoeld in artikel 13, eerste tot en met derde lid , de personen, bedoeld in artikel 14, eerste lid en de arbodienst;\nc. de maatregelen die de werkgever neemt ten aanzien van de bedrijven, inrichtingen of delen daarvan, bedoeld onder a;\nd. het tijdstip waarop en de frequentie waarmee wordt voldaan aan de verplichtingen, bedoeld onder b en c;\ne. een verbod op de exploitatie van het bedrijf, de inrichting of een deel daarvan, indien niet of niet voldoende is voldaan aan een of meer verplichtingen krachtens dit artikel;\nf. het toezicht op de naleving van het bij of krachtens dit artikel bepaalde.\n2 Onze Minister kan een bedrijf of een inrichting of een deel daarvan afzonderlijk aanwijzen ten aanzien waarvan op de werkgever een of meer van de verplichtingen bedoeld in of krachtens het eerste lid rusten indien zich in verband met de aanwezigheid van gevaarlijke stoffen bijzondere gevaren kunnen voordoen voor de veiligheid en de gezondheid van de daarin werkzame werknemers. Bij de aanwijzing wordt bepaald op welk tijdstip aan de betreffende verplichtingen moet zijn voldaan. De werking van de aanwijzing wordt opgeschort totdat de termijn voor het indienen van een bezwaar- of beroepschrift is verstreken of, indien bezwaar is gemaakt of beroep is ingesteld, op het bezwaar of beroep is beslist.\n3 Het niet naleven van de bij of krachtens het eerste lid, tweede volzin, gestelde regels wordt aangemerkt als strafbaar feit voor zover dat bij of krachtens algemene maatregel van bestuur is bepaald.",
               "whs_topics": [
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "prevention_services",
+                  "relevance": "high",
+                  "match_count": 2
+                },
                 {
                   "id": "risk_assessment",
                   "relevance": "high",
@@ -194,11 +307,6 @@
                 {
                   "id": "incident_reporting",
                   "relevance": "high",
-                  "match_count": 1
-                },
-                {
-                  "id": "hazardous_substances",
-                  "relevance": "medium",
                   "match_count": 1
                 }
               ],
@@ -214,8 +322,23 @@
               "id": "f1d517ef4bce51be",
               "number": "7",
               "title": "Artikel 7. Informatie aan het publiek",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 De toezichthouder stelt krachtens artikel 6, eerste lid, onder b , verschafte en bij algemene maatregel van bestuur aangewezen gegevens uit eigen beweging ter beschikking van het publiek. Bij of krachtens algemene maatregel van bestuur kunnen terzake regels worden gesteld.\n2 Onverminderd artikel 5.1, eerste lid, van de Wet open overheid en in afwijking van artikel 5.1, tweede en vijfde lid, van die wet blijft het verstrekken van gegevens als bedoeld in het eerste lid achterwege voor zover het belang daarvan niet opweegt tegen de volgende belangen: a. het belang, bedoeld in artikel 5.1, tweede lid, onder e, van de Wet open overheid ; b. het belang, bedoeld in artikel 5.1, tweede lid, onder h, van de Wet open overheid , voor zover het betreft het voorkomen van sabotage.\na. het belang, bedoeld in artikel 5.1, tweede lid, onder e, van de Wet open overheid ;\nb. het belang, bedoeld in artikel 5.1, tweede lid, onder h, van de Wet open overheid , voor zover het betreft het voorkomen van sabotage.\n3 Artikel 5.1, vierde lid, van de Wet open overheid is niet van toepassing op het op verzoek verstrekken van gegevens die door de daartoe aangewezen ambtenaar bedoeld in artikel 24 zijn verkregen in verband met de toepassing van het bepaalde bij of krachtens artikel 6 ter uitvoering van Richtlijn 2012/18/EU van het Europees Parlement en de Raad van 4 juli 2012 betreffende de beheersing van de gevaren van zware ongevallen waarbij gevaarlijke stoffen zijn betrokken, houdende wijziging en vervolgens intrekking van Richtlijn 96/82/EG van de Raad (PbEU 2012, L 197).\n4 Artikel 5.1, tweede lid, aanhef en onder b, van de Wet open overheid is op het op verzoek verstrekken van informatie over gegevens als bedoeld in het derde lid uitsluitend van toepassing, voorzover die gegevens een vertrouwelijk karakter hebben.\n5 Artikel 5.1, tweede lid, aanhef en onder h, van de Wet open overheid is op het op verzoek verstrekken van gegevens als bedoeld in het derde lid uitsluitend van toepassing voor zover het gegevens betreft die afbreuk kunnen doen aan de mogelijkheid van het voorkomen van sabotage.\n6 Op het op verzoek verstrekken van gegevens als bedoeld in het derde lid is artikel 5.1, vijfde lid, van de Wet open overheid niet van toepassing.",
               "whs_topics": [
+                {
+                  "id": "risk_assessment",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "incident_reporting",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "hazardous_substances",
+                  "relevance": "medium",
+                  "match_count": 1
+                },
                 {
                   "id": "employee_rights",
                   "relevance": "medium",
@@ -223,10 +346,10 @@
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
+                "score": 2,
+                "level": "medium",
                 "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "medium_keyword_matches": 2
               },
               "paragraphs": []
             },
@@ -234,19 +357,39 @@
               "id": "46ed1781845b0d3d",
               "number": "8",
               "title": "Artikel 8. Voorlichting en onderricht",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 De werkgever zorgt ervoor dat de werknemers doeltreffend worden ingelicht over de te verrichten werkzaamheden en de daaraan verbonden risico's, alsmede over de maatregelen die erop gericht zijn deze risico's te voorkomen of te beperken. Tevens zorgt de werkgever ervoor dat de werknemers doeltreffend worden ingelicht over de wijze waarop de deskundige bijstand, bedoeld in de artikelen 13 , 14 , 14a en 15 , in zijn bedrijf of inrichting is georganiseerd.\nTevens zorgt de werkgever ervoor dat de werknemers doeltreffend worden ingelicht over de wijze waarop de deskundige bijstand, bedoeld in de artikelen 13 , 14 , 14a en 15 , in zijn bedrijf of inrichting is georganiseerd.\n2 De werkgever zorgt ervoor dat aan de werknemers doeltreffend en aan hun onderscheiden taken aangepast onderricht wordt verstrekt met betrekking tot de arbeidsomstandigheden.\n3 Indien persoonlijke beschermingsmiddelen ter beschikking van de werknemers worden gesteld en indien op arbeidsmiddelen of anderszins beveiligingen zijn aangebracht, zorgt de werkgever ervoor dat de werknemers op de hoogte zijn van hun doel en werking en de wijze waarop zij deze dienen te gebruiken.\n4 De werkgever ziet toe op de naleving van de instructies en voorschriften gericht op het voorkomen of beperken van de in het eerste lid genoemde risico's alsmede op het juiste gebruik van persoonlijke beschermingsmiddelen.\n5 Indien binnen de onderneming werknemers jonger dan 18 jaar werkzaam zijn, houdt de werkgever bij de uitvoering van de in de voorgaande leden genoemde verplichtingen in het bijzonder rekening met de aan de jeugdige leeftijd inherente beperkte werkervaring en onvoltooide lichamelijke en geestelijke ontwikkeling van deze werknemers.",
               "whs_topics": [
+                {
+                  "id": "ppe",
+                  "relevance": "high",
+                  "match_count": 3
+                },
                 {
                   "id": "training",
                   "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
                   "match_count": 2
+                },
+                {
+                  "id": "work_equipment",
+                  "relevance": "high",
+                  "match_count": 1
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 2,
-                "level": "medium",
-                "high_keyword_matches": 1,
-                "medium_keyword_matches": 0
+                "score": 8,
+                "level": "critical",
+                "high_keyword_matches": 3,
+                "medium_keyword_matches": 2
               },
               "paragraphs": []
             },
@@ -254,8 +397,13 @@
               "id": "653390fae8964a3d",
               "number": "9",
               "title": "Artikel 9. Melding en registratie van arbeidsongevallen en beroepsziekten",
-              "text": "... Sla het regelingonderdeel op\n\n[Wijziging(en) zonder datum inwerkingtreding aanwezig. Zie het wijzigingenoverzicht .]",
+              "text": "1 De werkgever meldt arbeidsongevallen die leiden tot de dood, een blijvend letsel of een ziekenhuisopname direct aan de daartoe aangewezen toezichthouder en rapporteert hierover desgevraagd zo spoedig mogelijk aan deze toezichthouder.\n2 De werkgever houdt een lijst bij van de gemelde arbeidsongevallen en van arbeidsongevallen welke hebben geleid tot een verzuim van meer dan drie werkdagen en registreert daarop de aard en datum van het ongeval.\n3 De persoon, bedoeld in artikel 14, eerste lid , die belast is met de taak, bedoeld in onderdeel b van dat lid, of de arbodienst meldt beroepsziekten aan een door Onze Minister hiertoe aangewezen instelling.\n4 Onze Minister vergoedt ten laste van ’s Rijks kas de door de aangewezen instelling, bedoeld in het derde lid, gemaakte uitvoeringskosten overeenkomstig bij ministeriële regeling vast te stellen regels.\n5 Gelet op artikel 9, tweede lid, onderdeel b, van de Algemene verordening gegevensbescherming, is het verbod om gegevens over gezondheid te verwerken niet van toepassing indien de verwerking geschiedt door een werkgever en de verwerking noodzakelijk is om te voldoen aan de verplichtingen, genoemd in het eerste lid. Artikel 30, vierde lid, tweede zin, van de Uitvoeringswet Algemene verordening gegevensbescherming is van overeenkomstige toepassing.",
               "whs_topics": [
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
                 {
                   "id": "incident_reporting",
                   "relevance": "high",
@@ -265,13 +413,23 @@
                   "id": "documentation",
                   "relevance": "high",
                   "match_count": 1
+                },
+                {
+                  "id": "ppe",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "prevention_services",
+                  "relevance": "high",
+                  "match_count": 1
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 1,
-                "level": "medium",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 1
+                "score": 4,
+                "level": "high",
+                "high_keyword_matches": 1,
+                "medium_keyword_matches": 2
               },
               "paragraphs": []
             },
@@ -279,11 +437,31 @@
               "id": "205a2b15d60b51a6",
               "number": "10",
               "title": "Artikel 10. Voorkomen van gevaar voor derden",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "Indien bij of in rechtstreeks verband met de arbeid die de werkgever door zijn werknemers doet verrichten in een bedrijf of een inrichting of in de onmiddellijke omgeving daarvan gevaar kan ontstaan voor de veiligheid of de gezondheid van andere personen dan die werknemers, neemt de werkgever doeltreffende maatregelen ter voorkoming van dat gevaar.",
               "whs_topics": [
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 2
+                },
                 {
                   "id": "risk_assessment",
                   "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "health_surveillance",
+                  "relevance": "medium",
                   "match_count": 1
                 }
               ],
@@ -299,24 +477,39 @@
               "id": "dd863ada2915dfb3",
               "number": "11",
               "title": "Artikel 11. Algemene verplichtingen van de werknemers",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "De werknemer is verplicht om in zijn doen en laten op de arbeidsplaats, overeenkomstig zijn opleiding en de door de werkgever gegeven instructies, naar vermogen zorg te dragen voor zijn eigen veiligheid en gezondheid en die van de andere betrokken personen. Met name is hij verplicht om:\na. arbeidsmiddelen en gevaarlijke stoffen op de juiste wijze te gebruiken;\nb. de hem ter beschikking gestelde persoonlijke beschermingsmiddelen op de juiste wijze te gebruiken en na gebruik op de daartoe bestemde plaats op te bergen, een en ander voor zover niet krachtens deze wet is bepaald dat werknemers niet verplicht zijn beschermingsmiddelen als vorenbedoeld te gebruiken;\nc. de op arbeidsmiddelen of anderszins aangebrachte beveiligingen niet te veranderen of buiten noodzaak weg te halen en deze op de juiste wijze te gebruiken;\nd. mede te werken aan het voor hem georganiseerde onderricht bedoeld in artikel 8 ;\ne. de door hem opgemerkte gevaren voor de veiligheid of de gezondheid terstond ter kennis te brengen aan de werkgever of degene die namens deze ter plaatse met de leiding is belast;\nf. de werkgever en de de werknemers en de andere deskundige personen, bedoeld in artikel 13, eerste tot en met derde lid , de personen, bedoeld in artikel 14, eerste lid , en de arbodienst, indien nodig bij te staan bij de uitvoering van hun verplichtingen en taken op grond van deze wet.",
               "whs_topics": [
                 {
+                  "id": "ppe",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "training",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
                   "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "prevention_services",
                   "relevance": "high",
                   "match_count": 2
                 },
                 {
-                  "id": "employee_rights",
-                  "relevance": "medium",
+                  "id": "risk_assessment",
+                  "relevance": "high",
                   "match_count": 1
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "score": 6,
+                "level": "critical",
+                "high_keyword_matches": 2,
+                "medium_keyword_matches": 2
               },
               "paragraphs": []
             }
@@ -332,42 +525,32 @@
               "id": "50688762ff685900",
               "number": "12",
               "title": "Artikel 12. Samenwerking, overleg en bijzondere rechten van de ondernemingsraad, de",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 Bij de uitvoering van het arbeidsomstandighedenbeleid werken de werkgever en de werknemers samen.\n2 De werkgever voert overleg met de ondernemingsraad of de personeelsvertegenwoordiging over aangelegenheden die het arbeidsomstandighedenbeleid betreffen alsmede over de uitvoering van dit beleid, waarbij actief informatie wordt gewisseld.\n3 De werkgever voert in ondernemingen waarin in de regel minder dan 10 personen werkzaam zijn, bij het ontbreken van een ondernemingsraad of personeelsvertegenwoordiging, overleg met de belanghebbende werknemers over de risico-inventarisatie en -evaluatie, de organisatie van de deskundige bijstand, bedoeld in artikel 13, eerste tot en met derde lid , de arbodienst en de deskundige bijstand, bedoeld in artikel 15 .\n4 Aan de leden van de ondernemingsraad of de personeelsvertegenwoordiging wordt in verband met hun taak in het kader van de arbeidsomstandigheden van de werknemers: a. de mogelijkheid geboden zich met de toezichthouder tijdens zijn bezoek aan het bedrijf of de inrichting buiten tegenwoordigheid van anderen te onderhouden; b. de mogelijkheid geboden de toezichthouder tijdens zijn bezoek aan het bedrijf of de inrichting te vergezellen, behoudens voor zover deze te kennen geeft dat daartegen vanwege een goede uitoefening van zijn taak bezwaren bestaan.\na. de mogelijkheid geboden zich met de toezichthouder tijdens zijn bezoek aan het bedrijf of de inrichting buiten tegenwoordigheid van anderen te onderhouden;\nb. de mogelijkheid geboden de toezichthouder tijdens zijn bezoek aan het bedrijf of de inrichting te vergezellen, behoudens voor zover deze te kennen geeft dat daartegen vanwege een goede uitoefening van zijn taak bezwaren bestaan.\n5 Voor het bij of krachtens deze wet bepaalde treedt voor de toepassing van de afdelingen 3.6 en 4.1.2. van de Algemene wet bestuursrecht een ondernemingsraad of personeelsvertegenwoordiging in de plaats van de belanghebbende werknemers.\n6 Bij het ontbreken van de ondernemingsraad of personeelsvertegenwoordiging wordt, in afwijking van artikel 3.41 van de Algemene wet bestuursrecht , van een beschikking zo spoedig mogelijk door de werkgever mededeling gedaan aan de belanghebbende werknemers. Die beschikking treedt, in afwijking van artikel 3.40 van de Algemene wet bestuursrecht , voor hen niet eerder in werking dan nadat de werkgever aan de mededelingsplicht, als bedoeld in de vorige zin, heeft voldaan.",
               "whs_topics": [
                 {
                   "id": "employee_rights",
                   "relevance": "medium",
-                  "match_count": 1
-                }
-              ],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "45db5b945f4ce041",
-              "number": "13",
-              "title": "Artikel 13. Bijstand deskundige werknemers op het gebied van preventie en bescherming",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [
+                  "match_count": 3
+                },
                 {
-                  "id": "ppe",
+                  "id": "risk_assessment",
                   "relevance": "high",
-                  "match_count": 1
+                  "match_count": 2
+                },
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 2
                 },
                 {
                   "id": "prevention_services",
                   "relevance": "high",
-                  "match_count": 1
+                  "match_count": 2
                 },
                 {
-                  "id": "employee_rights",
-                  "relevance": "medium",
-                  "match_count": 1
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 2
                 }
               ],
               "amazon_logistics_relevance": {
@@ -379,22 +562,82 @@
               "paragraphs": []
             },
             {
-              "id": "bc40250f26483f40",
-              "number": "14",
-              "title": "Artikel 14. Maatwerkregeling aanvullende deskundige bijstand bij specifieke taken",
-              "text": "... Sla het regelingonderdeel op\n\n[Wijziging(en) zonder datum inwerkingtreding aanwezig. Zie het wijzigingenoverzicht .]",
+              "id": "45db5b945f4ce041",
+              "number": "13",
+              "title": "Artikel 13. Bijstand deskundige werknemers op het gebied van preventie en bescherming",
+              "text": "1 De werkgever laat zich ten aanzien van de naleving van zijn verplichtingen op grond van deze wet bijstaan door een of meer deskundige werknemers. Indien in het bedrijf of de inrichting van de werkgever een ondernemingsraad of personeelsvertegenwoordiging is ingesteld, wordt de keuze voor de deskundige werknemer, bedoeld in de eerste zin, en diens positionering, bepaald met instemming van die ondernemingsraad of personeelsvertegenwoordiging. Artikel 27, derde tot en met zesde lid, van de Wet op de ondernemingsraden is van overeenkomstige toepassing.\n2 Voorzover de mogelijkheden onvoldoende zijn om de bijstand binnen het bedrijf of de inrichting te organiseren, wordt de bijstand verleend door een combinatie van deskundige werknemers en andere deskundige personen.\n3 Indien er geen mogelijkheden zijn om de bijstand binnen het bedrijf of de inrichting te organiseren, wordt de bijstand verleend door andere deskundige personen.\n4 De werknemers en de andere deskundige personen beschikken over een zodanige deskundigheid, ervaring en uitrusting, zijn zodanig in aantal, gedurende zoveel tijd beschikbaar en zodanig georganiseerd, dat zij de bijstand naar behoren kunnen verlenen.\n5 De werkgever stelt de werknemers in de gelegenheid de bijstand zelfstandig en onafhankelijk te verlenen. De werknemers worden uit hoofde van een juiste taakuitoefening niet benadeeld in hun positie in het bedrijf of de inrichting. Artikel 21, vierde zin, van de Wet op de ondernemingsraden is van overeenkomstige toepassing.\n6 De deskundige personen verlenen hun bijstand met behoud van hun zelfstandigheid en van hun onafhankelijkheid ten opzichte van de werkgever.\n7 Het verlenen van bijstand omvat in ieder geval: a. het verlenen van medewerking aan het verrichten en opstellen van een risico-inventarisatie en -evaluatie als bedoeld in artikel 5 ; b. het adviseren aan onderscheidenlijk nauw samenwerken met de deskundige personen, bedoeld in artikel 14, eerste lid , de ondernemingsraad of de personeelsvertegenwoordiging, of, bij het ontbreken daarvan, de belanghebbende werknemers, inzake de genomen en de te nemen maatregelen, gericht op een zo goed mogelijk arbeidsomstandighedenbeleid; c. de uitvoering van de maatregelen, bedoeld in onderdeel b, dan wel de medewerking daaraan.\n7 Het verlenen van bijstand omvat in ieder geval:\na. het verlenen van medewerking aan het verrichten en opstellen van een risico-inventarisatie en -evaluatie als bedoeld in artikel 5 ;\nb. het adviseren aan onderscheidenlijk nauw samenwerken met de deskundige personen, bedoeld in artikel 14, eerste lid , de ondernemingsraad of de personeelsvertegenwoordiging, of, bij het ontbreken daarvan, de belanghebbende werknemers, inzake de genomen en de te nemen maatregelen, gericht op een zo goed mogelijk arbeidsomstandighedenbeleid;\nc. de uitvoering van de maatregelen, bedoeld in onderdeel b, dan wel de medewerking daaraan.\n8 Een afschrift van een advies als bedoeld in het zevende lid, onderdeel b, wordt aan de werkgever gezonden.\n9 In de risico-inventarisatie en -evaluatie, bedoeld in artikel 5 , worden de maatregelen beschreven die nodig zijn om te voldoen aan het vierde en tiende lid.\n10 In afwijking van het eerste tot en met het derde lid, kunnen bij werkgevers met niet meer dan 25 werknemers de taken in het kader van de bijstand ook worden verricht door de werkgever zelf, indien deze natuurlijk persoon is, of door de directeur indien de werkgever rechtspersoon is, indien deze personen beschikken over voldoende deskundigheid, ervaring en uitrusting om deze taken naar behoren te vervullen.",
               "whs_topics": [
                 {
-                  "id": "prevention_services",
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 3
+                },
+                {
+                  "id": "risk_assessment",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "ppe",
                   "relevance": "high",
                   "match_count": 1
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
+                "score": 2,
+                "level": "medium",
                 "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "medium_keyword_matches": 2
+              },
+              "paragraphs": []
+            },
+            {
+              "id": "bc40250f26483f40",
+              "number": "14",
+              "title": "Artikel 14. Maatwerkregeling aanvullende deskundige bijstand bij specifieke taken",
+              "text": "1 In aanvulling op artikel 13 laat de werkgever zich bij de volgende taken bijstaan door een of meer deskundige personen ten behoeve van wie overeenkomstig artikel 20 een certificaat is afgegeven of die als bedrijfsarts is ingeschreven in een erkend specialistenregister als bedoeld in artikel 14 van de Wet op de beroepen in de individuele gezondheidszorg : a. het toetsen van de risico-inventarisatie en -evaluatie, bedoeld in artikel 5 , en daarover adviseren; b. het adviseren bij de begeleiding van werknemers die door ziekte niet in staat zijn hun arbeid te verrichten, met inbegrip van het adviseren bij de uitvoering van bij of krachtens artikel 25, eerste, tweede, derde, vierde en zevende lid van de Wet werk en inkomen naar arbeidsvermogen , dan wel bij of krachtens artikel 71a, eerste, tweede, derde, vierde en zevende lid, van de Wet op de arbeidsongeschiktheidsverzekering gestelde regels; c. het uitvoeren van: 1°. het arbeidsgezondheidskundig onderzoek, bedoeld in artikel 18 ; 2°. de aanstellingskeuring, indien de werkgever deze laat verrichten; 3°. de consultatie met betrekking tot gezondheidskundige vraagstukken in verband met de arbeid, anders dan de begeleiding, bedoeld onder b.\na. het toetsen van de risico-inventarisatie en -evaluatie, bedoeld in artikel 5 , en daarover adviseren;\nb. het adviseren bij de begeleiding van werknemers die door ziekte niet in staat zijn hun arbeid te verrichten, met inbegrip van het adviseren bij de uitvoering van bij of krachtens artikel 25, eerste, tweede, derde, vierde en zevende lid van de Wet werk en inkomen naar arbeidsvermogen , dan wel bij of krachtens artikel 71a, eerste, tweede, derde, vierde en zevende lid, van de Wet op de arbeidsongeschiktheidsverzekering gestelde regels;\nc. het uitvoeren van: 1°. het arbeidsgezondheidskundig onderzoek, bedoeld in artikel 18 ; 2°. de aanstellingskeuring, indien de werkgever deze laat verrichten; 3°. de consultatie met betrekking tot gezondheidskundige vraagstukken in verband met de arbeid, anders dan de begeleiding, bedoeld onder b.\nc. het uitvoeren van:\n1°. het arbeidsgezondheidskundig onderzoek, bedoeld in artikel 18 ;\n2°. de aanstellingskeuring, indien de werkgever deze laat verrichten;\n3°. de consultatie met betrekking tot gezondheidskundige vraagstukken in verband met de arbeid, anders dan de begeleiding, bedoeld onder b.\n2 Bij de toepassing van het eerste lid wordt het volgende in acht genomen: a. de bijstand bij de taken, bedoeld in het eerste lid, wordt doeltreffend uitgevoerd; b. de bijstand bij de taak, bedoeld in het eerste lid, onderdeel a, wordt binnen het bedrijf of de inrichting georganiseerd; c. voorzover de mogelijkheden onvoldoende zijn om de bijstand bij de taak, bedoeld in het eerste lid, onderdeel a, binnen het bedrijf of de inrichting te organiseren, wordt de bijstand verleend door een of meer andere deskundige personen als bedoeld in het eerste lid, aanhef; d. de personen die de bijstand verrichten, hebben een zodanige uitrusting en zijn zodanig in aantal, gedurende zoveel tijd beschikbaar en zodanig georganiseerd, dat zij de bijstand bij de taken, bedoeld in het eerste lid, naar behoren kunnen verlenen; e. er is een doeltreffende toegang tot de bedrijfsarts; f. de bedrijfsarts is in de gelegenheid iedere arbeidsplaats in het bedrijf of de inrichting van de werkgever te bezoeken; g. tenzij zwaarwegende argumenten zich daartegen verzetten, honoreert de bedrijfsarts een verzoek van de werknemer om in verband met een door hem gegeven advies dat betrekking heeft op de taken, bedoeld in het eerste lid, onder b en c, zo spoedig mogelijk een andere bedrijfsarts te raadplegen; h. de bedrijfsarts heeft een adequate procedure voor het afwikkelen van klachten; i. de personen die bijstand verrichten, werken nauw samen met en adviseren en verlenen medewerking aan de in artikel 13, eerste lid , genoemde deskundige personen, de ondernemingsraad of de personeelsvertegenwoordiging, of, bij het ontbreken daarvan, de belanghebbende werknemers, inzake te nemen, genomen en uit te voeren maatregelen gericht op een zo goed mogelijk arbeidsomstandighedenbeleid; j. de bedrijfsarts adviseert over preventieve maatregelen betreffende het algemeen arbeidsomstandighedenbeleid, bedoeld in artikel 3 .\n2 Bij de toepassing van het eerste lid wordt het volgende in acht genomen:\na. de bijstand bij de taken, bedoeld in het eerste lid, wordt doeltreffend uitgevoerd;\nb. de bijstand bij de taak, bedoeld in het eerste lid, onderdeel a, wordt binnen het bedrijf of de inrichting georganiseerd;\nc. voorzover de mogelijkheden onvoldoende zijn om de bijstand bij de taak, bedoeld in het eerste lid, onderdeel a, binnen het bedrijf of de inrichting te organiseren, wordt de bijstand verleend door een of meer andere deskundige personen als bedoeld in het eerste lid, aanhef;\nd. de personen die de bijstand verrichten, hebben een zodanige uitrusting en zijn zodanig in aantal, gedurende zoveel tijd beschikbaar en zodanig georganiseerd, dat zij de bijstand bij de taken, bedoeld in het eerste lid, naar behoren kunnen verlenen;\ne. er is een doeltreffende toegang tot de bedrijfsarts;\nf. de bedrijfsarts is in de gelegenheid iedere arbeidsplaats in het bedrijf of de inrichting van de werkgever te bezoeken;\ng. tenzij zwaarwegende argumenten zich daartegen verzetten, honoreert de bedrijfsarts een verzoek van de werknemer om in verband met een door hem gegeven advies dat betrekking heeft op de taken, bedoeld in het eerste lid, onder b en c, zo spoedig mogelijk een andere bedrijfsarts te raadplegen;\nh. de bedrijfsarts heeft een adequate procedure voor het afwikkelen van klachten;\ni. de personen die bijstand verrichten, werken nauw samen met en adviseren en verlenen medewerking aan de in artikel 13, eerste lid , genoemde deskundige personen, de ondernemingsraad of de personeelsvertegenwoordiging, of, bij het ontbreken daarvan, de belanghebbende werknemers, inzake te nemen, genomen en uit te voeren maatregelen gericht op een zo goed mogelijk arbeidsomstandighedenbeleid;\nj. de bedrijfsarts adviseert over preventieve maatregelen betreffende het algemeen arbeidsomstandighedenbeleid, bedoeld in artikel 3 .\n3 Een afschrift van een advies als bedoeld in het eerste lid, onderdeel a, wordt door de degene die dit advies heeft opgesteld gezonden aan de ondernemingsraad of de personeelsvertegenwoordiging. Bij het ontbreken van een ondernemingsraad of personeelsvertegenwoordiging wordt een afschrift van dit advies zo spoedig mogelijk door de werkgever gezonden aan de belanghebbende werknemers.\n4 De wijze waarop de bijstandverlening plaatsvindt met betrekking tot de taken, bedoeld in de artikelen 9, derde lid , 14 en 14a alsmede de daarop berustende bepalingen, wordt door of vanwege een overeenkomst tussen de werkgever en de deskundige personen, bedoeld in artikel 14, eerste lid , schriftelijk vastgelegd. Onderdeel van de overeenkomst is de wijze waarop de in de aanhef van dit artikel genoemde personen in het bedrijf of de inrichting van de werkgever met inachtneming van de professionele dienstverlening uitvoering kunnen geven aan de verplichtingen die op grond van de in de eerste zin bedoelde taken op hen rusten.\n5 Aangaande de bedrijfsarts wordt in de overeenkomst, bedoeld in het vierde lid, in het bijzonder aandacht besteed aan de wijze waarop aan het tweede lid, onderdelen f tot en met j, en artikel 9, derde lid , uitvoering wordt gegeven.\n6 Bij de gegevensverwerking noodzakelijk voor de uitvoering van de taak, bedoeld in het eerste lid, onderdeel b, kan gebruik worden gemaakt van het burgerservicenummer.\n7 Artikel 464 van Boek 7 van het Burgerlijk Wetboek voorzover het betreft de overeenkomstige toepassing van de artikelen 457 en 464, tweede lid, onder b, van Boek 7 van het Burgerlijk Wetboek , is niet van toepassing indien in verband met de uitvoering van deze wet handelingen worden verricht op het gebied van de geneeskunst door personen die zijn belast met de taken, bedoeld in het eerste lid, onderdeel b.\n8 Artikel 13, vijfde en zesde lid , is van overeenkomstige toepassing.\n9 De organisatie van de bijstand bij de taken, bedoeld in het eerste lid, kan, met inachtneming van het tweede lid, plaatsvinden bij: a. collectieve arbeidsovereenkomst of bij regeling door of namens een daartoe bevoegd bestuursorgaan, of b. regeling waaromtrent de werkgever schriftelijk overeenstemming heeft bereikt met de ondernemingsraad of de personeelsvertegenwoordiging.\na. collectieve arbeidsovereenkomst of bij regeling door of namens een daartoe bevoegd bestuursorgaan, of\nb. regeling waaromtrent de werkgever schriftelijk overeenstemming heeft bereikt met de ondernemingsraad of de personeelsvertegenwoordiging.\n10 Indien zowel een collectieve arbeidsovereenkomst of een regeling als bedoeld in het negende lid, onderdeel a, als een regeling als bedoeld in het negende lid, onderdeel b, gelden, zijn de in die overeenkomst en regelingen gegeven bepalingen naast elkaar van toepassing. In geval van strijd zijn de bepalingen van de collectieve arbeidsovereenkomst of de regeling, bedoeld in het negende lid, onderdeel a, van toepassing.\n11 Voor de toepassing van dit artikel en de daarop berustende bepalingen geldt een collectieve arbeidsovereenkomst als bedoeld in het negende lid, onderdeel a, en een regeling als bedoeld in het negende lid, onderdelen a en b, gedurende 5 jaren, te rekenen vanaf het tijdstip waarop die collectieve arbeidsovereenkomst of die regeling ingaat. Bij wijziging van de in de eerste zin bedoelde collectieve arbeidsovereenkomst of regeling binnen 5 jaren na inwerkingtreding, wordt het in de eerste zin bedoelde tijdvak beëindigd op het tijdstip van inwerkingtreding van de gewijzigde collectieve arbeidsovereenkomst of regeling.\n12 Het eerste lid, aanhef en onderdeel a, is niet van toepassing ten aanzien van de werkgever: a. die werknemers arbeid laat verrichten voor een tijdsduur van in totaal, voor alle werknemers gezamenlijk, ten hoogste 40 uur per week, of b. met in de regel ten hoogste 25 werknemers, indien voor het opstellen van een risico-inventarisatie en -evaluatie gebruik wordt gemaakt van: 1°. een model dat is opgenomen in een collectieve arbeidsovereenkomst of in een regeling door een daartoe bevoegd bestuursorgaan en een onverplicht karakter heeft, of 2°. een instrument dat is aangemeld bij Onze Minister dan wel bij een door Onze Minister aangewezen instelling.\n12 Het eerste lid, aanhef en onderdeel a, is niet van toepassing ten aanzien van de werkgever:\na. die werknemers arbeid laat verrichten voor een tijdsduur van in totaal, voor alle werknemers gezamenlijk, ten hoogste 40 uur per week, of\nb. met in de regel ten hoogste 25 werknemers, indien voor het opstellen van een risico-inventarisatie en -evaluatie gebruik wordt gemaakt van: 1°. een model dat is opgenomen in een collectieve arbeidsovereenkomst of in een regeling door een daartoe bevoegd bestuursorgaan en een onverplicht karakter heeft, of 2°. een instrument dat is aangemeld bij Onze Minister dan wel bij een door Onze Minister aangewezen instelling.\n1°. een model dat is opgenomen in een collectieve arbeidsovereenkomst of in een regeling door een daartoe bevoegd bestuursorgaan en een onverplicht karakter heeft, of\n2°. een instrument dat is aangemeld bij Onze Minister dan wel bij een door Onze Minister aangewezen instelling.\n13 Bij of krachtens algemene maatregel van bestuur worden regels gesteld voor: a. de tijdsduur van arbeid die buiten beschouwing wordt gelaten bij de toepassing van het twaalfde lid, onderdeel a; b. het model en het instrument, bedoeld in het twaalfde lid, onderdeel b.\n13 Bij of krachtens algemene maatregel van bestuur worden regels gesteld voor:\na. de tijdsduur van arbeid die buiten beschouwing wordt gelaten bij de toepassing van het twaalfde lid, onderdeel a;\nb. het model en het instrument, bedoeld in het twaalfde lid, onderdeel b.\n14 Bij of krachtens algemene maatregel van bestuur kan worden bepaald dat de bijstand bij een of meer taken als bedoeld in het eerste lid, onderdelen b en c, niet verplicht is met inachtneming van bij of krachtens die algemene maatregel van bestuur gegeven voorschriften.\n15 Het niet naleven van de bij of krachtens deze wet vastgestelde verplichtingen, bedoeld in het tweede lid, onder g, h en j, door de bedrijfsarts, de verplichting, bedoeld in het tweede lid, onder i, door de personen, bedoeld in het eerste lid, en de verplichting, bedoeld in het derde lid, eerste zin, door de personen, bedoeld in het eerste lid, wordt aangemerkt als een overtreding.",
+              "whs_topics": [
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "health_surveillance",
+                  "relevance": "medium",
+                  "match_count": 3
+                },
+                {
+                  "id": "risk_assessment",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "prevention_services",
+                  "relevance": "high",
+                  "match_count": 2
+                }
+              ],
+              "amazon_logistics_relevance": {
+                "score": 4,
+                "level": "high",
+                "high_keyword_matches": 1,
+                "medium_keyword_matches": 2
               },
               "paragraphs": []
             },
@@ -402,10 +645,30 @@
               "id": "e8bd89e03119ef82",
               "number": "14a",
               "title": "Artikel 14a. Vangnetregeling aanvullende deskundige bijstand op het gebied van preventie",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 Indien de bijstand bij de taken, bedoeld in artikel 14, eerste lid , niet is georganiseerd met toepassing van artikel 14, negende lid , wordt deze bijstand georganiseerd met inachtneming van dit artikel.\n2 De werkgever laat zich met betrekking tot de taken, bedoeld in artikel 14, eerste lid , bijstaan door een arbodienst, ten behoeve waarvan overeenkomstig artikel 20 een certificaat is afgegeven en die deel uitmaakt van de organisatie van het bedrijf of de inrichting.\n3 Voorzover de mogelijkheden onvoldoende zijn om de bijstand binnen het bedrijf of de inrichting te organiseren, wordt de bijstand verleend door een andere arbodienst ten behoeve waarvan, overeenkomstig artikel 20 , een certificaat is afgegeven.\n4 De werknemers van een arbodienst werken nauw samen met en adviseren en verlenen medewerking aan de in artikel 13, eerste lid , genoemde deskundige personen, de ondernemingsraad of de personeelsvertegenwoordiging, of, bij het ontbreken daarvan, de belanghebbende werknemers, inzake te nemen, genomen en uit te voeren maatregelen gericht op een zo goed mogelijk arbeidsomstandighedenbeleid. Het niet naleven van deze verplichting door de werknemers van een arbodienst wordt aangemerkt als een overtreding.\n5 Artikel 13, vijfde en zesde lid , is van overeenkomstige toepassing.\n6 Artikel 14, tweede lid, onder a en onder d tot en met j, derde tot en met zevende lid en twaalfde tot en met vijftiende lid , is van toepassing.",
               "whs_topics": [
                 {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
                   "id": "prevention_services",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 2
+                },
+                {
+                  "id": "penalties",
                   "relevance": "high",
                   "match_count": 1
                 }
@@ -422,24 +685,39 @@
               "id": "3e56e35a64f94794",
               "number": "15",
               "title": "Artikel 15. Deskundige bijstand op het gebied van bedrijfshulpverlening",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 De werkgever laat zich ten aanzien van de naleving van zijn verplichtingen op grond van artikel 3, eerste lid, onder e, van deze wet bijstaan door een of meer werknemers die door hem zijn aangewezen als bedrijfshulpverleners.\n2 Het verlenen van de bijstand houdt in elk geval in: a. het verlenen van eerste hulp bij ongevallen; b. het beperken en het bestrijden van brand en het beperken van de gevolgen van ongevallen; c. het in noodsituaties alarmeren en evacueren van alle werknemers en andere personen in het bedrijf of de inrichting.\n2 Het verlenen van de bijstand houdt in elk geval in:\na. het verlenen van eerste hulp bij ongevallen;\nb. het beperken en het bestrijden van brand en het beperken van de gevolgen van ongevallen;\nc. het in noodsituaties alarmeren en evacueren van alle werknemers en andere personen in het bedrijf of de inrichting.\n3 De bedrijfshulpverleners beschikken over een zodanige opleiding en uitrusting, zijn zodanig in aantal en zodanig georganiseerd dat zij de in het tweede lid genoemde taken naar behoren kunnen vervullen.",
               "whs_topics": [
                 {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
                   "id": "first_aid",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "training",
                   "relevance": "high",
                   "match_count": 1
                 },
                 {
-                  "id": "prevention_services",
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "incident_reporting",
                   "relevance": "high",
                   "match_count": 1
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "score": 3,
+                "level": "high",
+                "high_keyword_matches": 1,
+                "medium_keyword_matches": 1
               },
               "paragraphs": []
             },
@@ -447,7 +725,7 @@
               "id": "c731643741dc1fca",
               "number": "15a",
               "title": "Artikel 15a. Informatierechten deskundige werknemers en personen, bedrijfshulpverleners",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "De werkgever zorgt ervoor dat de deskundige werknemers en de andere deskundige personen, bedoeld in artikel 13 , de personen, bedoeld in artikel 14, eerste lid , de bedrijfshulpverleners, bedoeld in artikel 15 , en de arbodienst kennis kunnen nemen van:\na. de ongevalsrapportages en de lijst van arbeidsongevallen, bedoeld in artikel 9 ;\nb. een eis als bedoeld in artikel 27, eerste lid ;\nc. een bevel als bedoeld in artikel 28, eerste lid ;\nd. een bevel als bedoeld in artikel 28a, tweede lid ;\ne. een beschikking tot oplegging van een last onder bestuursdwang of tot oplegging van een last onder dwangsom als bedoeld in artikel 28b ;\nf. een verzoek om ontheffing als bedoeld in artikel 30, tweede lid ;\ng. een rapport als bedoeld in artikel 36, eerste lid ;\nh. een beschikking als bedoeld in artikel 37, eerste lid .",
               "whs_topics": [
                 {
                   "id": "employee_rights",
@@ -457,14 +735,24 @@
                 {
                   "id": "prevention_services",
                   "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "incident_reporting",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
                   "match_count": 1
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
+                "score": 1,
+                "level": "medium",
                 "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "medium_keyword_matches": 1
               },
               "paragraphs": []
             }
@@ -480,19 +768,39 @@
               "id": "641032aadabee737",
               "number": "16",
               "title": "Artikel 16. Nadere regels met betrekking tot arbeidsomstandigheden alsmede uitzonderingen",
-              "text": "... Sla het regelingonderdeel op\n\n[Wijziging(en) zonder datum inwerkingtreding aanwezig. Zie het wijzigingenoverzicht .]",
+              "text": "1 Bij of krachtens algemene maatregel van bestuur worden regels gesteld in verband met arbeidsomstandigheden van de werknemers.\n2 De in het eerste lid bedoelde regels a. hebben betrekking op de arbozorg en de organisatie van de arbeid, de inrichting van de arbeidsplaatsen, het werken met gevaarlijke stoffen en biologische agentia, de mate van fysieke belasting waaraan werknemers blootstaan, de fysische factoren die zich op de arbeidsplaats voordoen, de bij de arbeid gebruikte arbeidsmiddelen en persoonlijke beschermingsmiddelen en de op de arbeidsplaats te gebruiken veiligheids- en gezondheidssignalering en b. kunnen mede strekken ter uitvoering van de artikelen 3 , 4 , 5 , 8 , 9 , 13 , 14 , 14a , 15 en 18 .\n2 De in het eerste lid bedoelde regels\na. hebben betrekking op de arbozorg en de organisatie van de arbeid, de inrichting van de arbeidsplaatsen, het werken met gevaarlijke stoffen en biologische agentia, de mate van fysieke belasting waaraan werknemers blootstaan, de fysische factoren die zich op de arbeidsplaats voordoen, de bij de arbeid gebruikte arbeidsmiddelen en persoonlijke beschermingsmiddelen en de op de arbeidsplaats te gebruiken veiligheids- en gezondheidssignalering en\nb. kunnen mede strekken ter uitvoering van de artikelen 3 , 4 , 5 , 8 , 9 , 13 , 14 , 14a , 15 en 18 .\n3 De in het eerste en tweede lid bedoelde regels kunnen inhouden: a. een verbod om bepaalde bij die maatregel omschreven arbeid te verrichten of te doen verrichten waaraan bijzondere gevaren voor de veiligheid of de gezondheid zijn verbonden; b. een verbod om bepaalde bij die maatregel omschreven arbeid te verrichten of te doen verrichten, indien met betrekking tot die arbeid niet aan de bij of krachtens die maatregel vastgestelde voorwaarden of voorschriften is voldaan; c. een verbod om bepaalde bij die maatregel omschreven gevaarlijke stoffen of voorwerpen voorhanden te hebben, waaraan bijzondere gevaren voor de veiligheid of de gezondheid zijn verbonden; d. een verbod om bepaalde bij die maatregel omschreven gevaarlijke stoffen of voorwerpen voorhanden te hebben, indien met betrekking tot die stoffen of voorwerpen niet aan de bij of krachtens die maatregel vastgestelde voorwaarden of voorschriften is voldaan; e. een verbod om bepaalde bij die maatregel omschreven arbeid te verrichten of te doen verrichten indien de werknemers niet arbeidsgezondheidskundig zijn onderzocht.\n3 De in het eerste en tweede lid bedoelde regels kunnen inhouden:\na. een verbod om bepaalde bij die maatregel omschreven arbeid te verrichten of te doen verrichten waaraan bijzondere gevaren voor de veiligheid of de gezondheid zijn verbonden;\nb. een verbod om bepaalde bij die maatregel omschreven arbeid te verrichten of te doen verrichten, indien met betrekking tot die arbeid niet aan de bij of krachtens die maatregel vastgestelde voorwaarden of voorschriften is voldaan;\nc. een verbod om bepaalde bij die maatregel omschreven gevaarlijke stoffen of voorwerpen voorhanden te hebben, waaraan bijzondere gevaren voor de veiligheid of de gezondheid zijn verbonden;\nd. een verbod om bepaalde bij die maatregel omschreven gevaarlijke stoffen of voorwerpen voorhanden te hebben, indien met betrekking tot die stoffen of voorwerpen niet aan de bij of krachtens die maatregel vastgestelde voorwaarden of voorschriften is voldaan;\ne. een verbod om bepaalde bij die maatregel omschreven arbeid te verrichten of te doen verrichten indien de werknemers niet arbeidsgezondheidskundig zijn onderzocht.\n4 Bij algemene maatregel van bestuur kan worden bepaald dat deze wet en de daarop berustende bepalingen geheel of gedeeltelijk niet van toepassing zijn op: a. arbeid verricht in of op een luchtvaartuig, dan wel een zeeschip of binnenvaartuig, dan wel een voertuig op een openbare weg of een spoor- of tramweg; b. arbeid verricht in militaire dienst; c. arbeid verricht door werknemers en verrichtingen als bedoeld in artikel 2, onderdeel b , van leerlingen en studenten in onderwijsinrichtingen; d. arbeid verricht bij een verkenningsonderzoek, het opsporen of winnen van delfstoffen of aardwarmte dan wel het opslaan van stoffen als bedoeld in de Mijnbouwwet; e. arbeid verricht binnen de exclusieve economische zone.\na. arbeid verricht in of op een luchtvaartuig, dan wel een zeeschip of binnenvaartuig, dan wel een voertuig op een openbare weg of een spoor- of tramweg;\nb. arbeid verricht in militaire dienst;\nc. arbeid verricht door werknemers en verrichtingen als bedoeld in artikel 2, onderdeel b , van leerlingen en studenten in onderwijsinrichtingen;\nd. arbeid verricht bij een verkenningsonderzoek, het opsporen of winnen van delfstoffen of aardwarmte dan wel het opslaan van stoffen als bedoeld in de Mijnbouwwet;\ne. arbeid verricht binnen de exclusieve economische zone.\n5 De in het derde lid, onder e, bedoelde maatregel stelt het verrichten van arbeid slechts afhankelijk van het resultaat van een arbeidsgezondheidskundig onderzoek voor zover die arbeid bijzondere gevaren meebrengt voor het leven of de gezondheid van de werknemer zelf of van andere personen of voor zover dit om andere bijzondere redenen geboden is. Bij of krachtens algemene maatregel van bestuur worden met betrekking tot dit arbeidsgezondheidskundig onderzoek en de wijze van registratie, verwerking en bewaring van de uitslag daarvan nadere regels gesteld. Deze hebben in ieder geval betrekking op de gevallen waarin en de wijze waarop een verzoek tot herkeuring kan worden gedaan.\n6 Bij algemene maatregel van bestuur kunnen met betrekking tot de arbeid of de verrichtingen: a. bedoeld in het vierde lid; b. verricht in de burgerlijke openbare dienst; c. verricht in een gevangenis of huis van bewaring als bedoeld in de Penitentiaire beginselenwet , een justitiële inrichting voor verpleging van ter beschikking gestelden als bedoeld in de Beginselenwet verpleging ter beschikking gestelden of een inrichting als bedoeld in de Beginselenwet justitiële jeugdinrichtingen , regels worden gesteld die afwijken van deze wet of de daarop berustende bepalingen of strekken tot aanvulling daarvan. Met betrekking tot de arbeid of de verrichtingen, bedoeld in het vierde lid, onder c, kan bij algemene maatregel van bestuur worden bepaald dat afdeling 4.1.2 van de Algemene wet bestuursrecht niet van toepassing is.\n6 Bij algemene maatregel van bestuur kunnen met betrekking tot de arbeid of de verrichtingen:\na. bedoeld in het vierde lid;\nb. verricht in de burgerlijke openbare dienst;\nc. verricht in een gevangenis of huis van bewaring als bedoeld in de Penitentiaire beginselenwet , een justitiële inrichting voor verpleging van ter beschikking gestelden als bedoeld in de Beginselenwet verpleging ter beschikking gestelden of een inrichting als bedoeld in de Beginselenwet justitiële jeugdinrichtingen ,\nregels worden gesteld die afwijken van deze wet of de daarop berustende bepalingen of strekken tot aanvulling daarvan. Met betrekking tot de arbeid of de verrichtingen, bedoeld in het vierde lid, onder c, kan bij algemene maatregel van bestuur worden bepaald dat afdeling 4.1.2 van de Algemene wet bestuursrecht niet van toepassing is.\n7 Bij algemene maatregel van bestuur kan worden bepaald dat de verplichting tot naleving van daarbij aangewezen voorschriften van deze wet of de daarop berustende bepalingen, voor zover zij betrekking hebben op arbeid waaraan bijzondere gevaren voor de veiligheid of de gezondheid zijn verbonden, dan wel noodzakelijk zijn ter uitvoering van verdragen of besluiten van volkenrechtelijke organisaties, zich mede richt tot: a. een zelfstandige; b. een werkgever die deze arbeid zelf verricht; c. degene bij wie vrijwilligers werkzaam zijn; d. een vrijwilliger.\na. een zelfstandige;\nb. een werkgever die deze arbeid zelf verricht;\nc. degene bij wie vrijwilligers werkzaam zijn;\nd. een vrijwilliger.\n8 Bij algemene maatregel van bestuur kan worden bepaald dat de verplichting tot naleving van daarbij aangegeven voorschriften in de gevallen bij die maatregel omschreven rust op een ander dan de werkgever. Aangewezen kunnen worden de eigenaar of beheerder dan wel degene die anderszins bevoegd is te beslissen over het ontwerp, de vervaardiging dan wel het onderhoud van arbeidsplaatsen en arbeidsmiddelen, zoals zonodig nader bij die maatregel is bepaald.\n9 De in het eerste lid bedoelde regels kunnen betrekking hebben op andere onderwerpen dan die genoemd in het tweede lid of zich richten tot andere personen dan de werkgever of de in het zevende en achtste lid bedoelde personen, indien dat noodzakelijk is ter uitvoering van verdragen of besluiten van volkenrechtelijke organisaties met betrekking tot de verbetering van de veiligheid of de gezondheid.\n10 De werkgever, dan wel een ander dan de werkgever bedoeld in het zevende, achtste of negende lid en de werknemers zijn verplicht tot naleving van de voorschriften en verboden vastgesteld bij of krachtens de op grond van dit artikel, artikel 20, eerste lid , en artikel 24, negende lid , vastgestelde algemene maatregel van bestuur voorzover en op de wijze als bij of krachtens deze maatregel is bepaald.\n11 Het niet naleven van de in het tiende lid bedoelde voorschriften en verboden kan worden aangemerkt als strafbaar feit.",
               "whs_topics": [
+                {
+                  "id": "ppe",
+                  "relevance": "high",
+                  "match_count": 3
+                },
                 {
                   "id": "workplace_design",
                   "relevance": "high",
-                  "match_count": 1
+                  "match_count": 3
+                },
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "health_surveillance",
+                  "relevance": "medium",
+                  "match_count": 3
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 2
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "score": 8,
+                "level": "critical",
+                "high_keyword_matches": 3,
+                "medium_keyword_matches": 2
               },
               "paragraphs": []
             },
@@ -500,8 +808,53 @@
               "id": "21575bd152cdf289",
               "number": "17",
               "title": "Artikel 17. Maatwerk door werkgevers en werknemers",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "Bij algemene maatregel van bestuur kan, met inachtneming van in die maatregel gegeven voorschriften, worden bepaald dat aan een of meer van de krachtens deze wet vastgestelde bepalingen op een andere wijze kan worden voldaan dan in die bepalingen is aangegeven, echter uitsluitend bij collectieve regeling als bedoeld in artikel 1:3, eerste lid van de Arbeidstijdenwet , dan wel een regeling waaromtrent de werkgever schriftelijk overeenstemming heeft bereikt met de ondernemingsraad of de personeelsvertegenwoordiging. Daarbij wordt te allen tijde in acht genomen dat geen afbreuk wordt gedaan aan het beschermingsniveau van de in de eerste volzin bedoelde bepalingen.",
               "whs_topics": [
+                {
+                  "id": "documentation",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "ppe",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "working_hours",
+                  "relevance": "medium",
+                  "match_count": 1
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 1
+                }
+              ],
+              "amazon_logistics_relevance": {
+                "score": 1,
+                "level": "medium",
+                "high_keyword_matches": 0,
+                "medium_keyword_matches": 1
+              },
+              "paragraphs": []
+            },
+            {
+              "id": "788c41d6f22e4670",
+              "number": "18",
+              "title": "Artikel 18. Arbeidsgezondheidskundig onderzoek",
+              "text": "De werkgever stelt de werknemers periodiek in de gelegenheid een onderzoek te ondergaan, dat erop is gericht de risico's die de arbeid voor de gezondheid van de werknemers met zich brengt zoveel mogelijk te voorkomen of te beperken.",
+              "whs_topics": [
+                {
+                  "id": "health_surveillance",
+                  "relevance": "medium",
+                  "match_count": 3
+                },
                 {
                   "id": "employer_obligations",
                   "relevance": "high",
@@ -514,30 +867,10 @@
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
+                "score": 1,
+                "level": "medium",
                 "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "788c41d6f22e4670",
-              "number": "18",
-              "title": "Artikel 18. Arbeidsgezondheidskundig onderzoek",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [
-                {
-                  "id": "health_surveillance",
-                  "relevance": "medium",
-                  "match_count": 3
-                }
-              ],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "medium_keyword_matches": 1
               },
               "paragraphs": []
             },
@@ -545,8 +878,18 @@
               "id": "0771c7c68bc337e6",
               "number": "19",
               "title": "Artikel 19. Verschillende werkgevers",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 Indien in een bedrijf of een inrichting verschillende werkgevers arbeid doen verrichten, werken zij onderling op doelmatige wijze samen teneinde de naleving van het bij of krachtens deze wet bepaalde te verzekeren.\n2 Alvorens werkzaamheden behorende tot een bij algemene maatregel van bestuur aangewezen categorie aanvangen zorgen de werkgevers ervoor dat schriftelijk is vastgelegd op welke wijze zal worden samengewerkt, welke voorzieningen daarbij zullen worden getroffen en op welke wijze op die voorzieningen toezicht zal worden uitgeoefend.",
               "whs_topics": [
+                {
+                  "id": "documentation",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 1
+                },
                 {
                   "id": "employer_obligations",
                   "relevance": "high",
@@ -565,12 +908,28 @@
               "id": "cc1a0384e8b7fcde",
               "number": "20",
               "title": "Artikel 20. Certificatie",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "1 Bij of krachtens algemene maatregel van bestuur worden regels gesteld op grond waarvan werkgevers, werknemers, andere personen of instellingen in het bezit moeten zijn van een of meer certificaten waaruit blijkt dat zij voldoen aan voorschriften, gesteld bij of krachtens deze wet.\n2 Onze Minister dan wel een door Onze Minister op verzoek aangewezen instelling beslist op aanvraag over de afgifte van het certificaat en is tevens bevoegd een afgegeven certificaat in te trekken of te schorsen. De Kaderwet zelfstandige bestuursorganen is niet van toepassing op aangewezen instellingen als bedoeld in de eerste zin.\n3 Een certificaat als bedoeld in het eerste lid en een aanwijzing als bedoeld in het tweede lid worden gegeven voor een beperkte tijdsduur. Aan een aanwijzing en een certificaat kunnen voorschriften worden verbonden. De bedoelde beperking en voorschriften worden in de aanwijzing en het certificaat vermeld.\n4 Bij of krachtens algemene maatregel van bestuur worden regels gesteld onder meer met betrekking tot: a. de wijze waarop de aanvraag om een certificaat als bedoeld in het eerste lid en een aanwijzing als bedoeld in het tweede lid wordt gedaan en de gegevens die daarbij van de aanvrager worden verlangd; b. de gronden waarop een aanwijzing kan worden gegeven, gewijzigd, geschorst of ingetrokken; c. de gronden waarop en de gevallen waarin de afgifte van een certificaat kan worden geweigerd dan wel een afgegeven certificaat kan worden geschorst of ingetrokken; d. de vergoeding van de kosten die is verschuldigd in verband met de afgifte van een certificaat of het geven van een aanwijzing.\na. de wijze waarop de aanvraag om een certificaat als bedoeld in het eerste lid en een aanwijzing als bedoeld in het tweede lid wordt gedaan en de gegevens die daarbij van de aanvrager worden verlangd;\nb. de gronden waarop een aanwijzing kan worden gegeven, gewijzigd, geschorst of ingetrokken;\nc. de gronden waarop en de gevallen waarin de afgifte van een certificaat kan worden geweigerd dan wel een afgegeven certificaat kan worden geschorst of ingetrokken;\nd. de vergoeding van de kosten die is verschuldigd in verband met de afgifte van een certificaat of het geven van een aanwijzing.\n5 De kosten van onderzoeken of nog steeds wordt voldaan aan de voorwaarden voor de afgifte van een certificaat onderscheidenlijk het geven van een aanwijzing, kunnen eveneens ten laste worden gebracht van de houder van het certificaat onderscheidenlijk de aangewezen instelling, mits deze onderzoeken en kosten zijn vastgelegd in een voorschrift als bedoeld in het derde lid.\n6 Indien bij de afgifte van een certificaat, het geven van een aanwijzing of het verrichten van een onderzoek als bedoeld in het vijfde lid, diensten van derden worden benut, kunnen ook de door die derden gemaakte kosten ten laste worden gebracht van de houder van het certificaat onderscheidenlijk de aangewezen instelling dan wel de aanvrager, bedoeld in het vierde lid, onder a.\n7 De berekening van de door derden gemaakte kosten als bedoeld in het zesde lid, voor zover deze ten laste worden gebracht van de houder van een certificaat onderscheidenlijk de aangewezen instelling dan wel de aanvrager, bedoeld in het vierde lid, onder a, geschiedt door die derden op zorgvuldige, transparante en éénduidige wijze met inachtneming van de redelijkheid en proportionaliteit.\n8 Bij ministeriële regeling worden nadere regels gesteld betreffende de wijze van betaling van de vergoeding van de kosten, bedoeld in het vierde, vijfde en zesde lid.",
+              "whs_topics": [
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "health_surveillance",
+                  "relevance": "medium",
+                  "match_count": 1
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
+                "score": 2,
+                "level": "medium",
+                "high_keyword_matches": 1,
                 "medium_keyword_matches": 0
               },
               "paragraphs": []
@@ -579,18 +938,23 @@
               "id": "6b2ae564c3490335",
               "number": "21",
               "title": "Artikel 21. Informatievoorziening",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 De krachtens artikel 20, tweede lid , aangewezen instellingen verstrekken desgevraagd kosteloos aan Onze Minister de voor de uitoefening van zijn taak benodigde inlichtingen. Onze Minister kan inzage vorderen van zakelijke gegevens en bescheiden, voor zover dat voor de vervulling van zijn taak redelijkerwijs nodig is.\n2 Bij algemene maatregel van bestuur kunnen de krachtens artikel 20, tweede lid , aangewezen instellingen worden verplicht tot het periodiek opstellen en toezenden aan Onze Minister van een verslag van de in artikel 20, tweede lid , genoemde werkzaamheden en de rechtmatigheid en doeltreffendheid van die werkzaamheden en werkwijze in de afgelopen periode.",
               "whs_topics": [
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 2
+                },
                 {
                   "id": "employee_rights",
                   "relevance": "medium",
-                  "match_count": 1
+                  "match_count": 2
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
+                "score": 2,
+                "level": "medium",
+                "high_keyword_matches": 1,
                 "medium_keyword_matches": 0
               },
               "paragraphs": []
@@ -599,12 +963,12 @@
               "id": "289020bba57e3716",
               "number": "22",
               "title": "Artikel 22. Aanwijzingen",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 Onze Minister kan de krachtens artikel 20, tweede lid , aangewezen instellingen aanwijzingen geven met betrekking tot de uitoefening van hun taak. Hij treedt daarbij niet in individuele gevallen.\n2 De krachtens artikel 20, tweede lid , aangewezen instellingen zijn gehouden overeenkomstig de aanwijzing, bedoeld in het eerste lid, te handelen.",
               "whs_topics": [],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
+                "score": 2,
+                "level": "medium",
+                "high_keyword_matches": 1,
                 "medium_keyword_matches": 0
               },
               "paragraphs": []
@@ -613,12 +977,18 @@
               "id": "fdb1b4412e66b6a3",
               "number": "23",
               "title": "Artikel 23. Taakverwaarlozing",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "Bij algemene maatregel van bestuur kunnen voorzieningen worden getroffen voor het geval de krachtens artikel 20, tweede lid , aangewezen instellingen hun uit deze wet voortvloeiende verplichtingen niet naar behoren nakomen.",
+              "whs_topics": [
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 2
+                }
+              ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
+                "score": 2,
+                "level": "medium",
+                "high_keyword_matches": 1,
                 "medium_keyword_matches": 0
               },
               "paragraphs": []
@@ -635,13 +1005,39 @@
               "id": "b6ec4585798bbbff",
               "number": "24",
               "title": "Artikel 24. Ambtenaren belast met het toezicht",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "1 Met het toezicht op de naleving van het bepaalde bij of krachtens deze wet zijn belast de bij besluit van Onze Minister aangewezen onder hem ressorterende ambtenaren.\n2 Met betrekking tot door Onze Minister aangewezen categorieën van arbeid zijn met het toezicht op de naleving van het bepaalde bij of krachtens deze wet belast of mede belast de door hem aangewezen andere ambtenaren dan de in het eerste lid bedoelde. Indien ambtenaren worden aangewezen die ressorteren onder een andere minister, wordt het besluit tot aanwijzing van die ambtenaren genomen door Onze Minister en die andere minister gezamenlijk. Van een besluit als bedoeld in het eerste lid en in dit lid wordt mededeling gedaan door plaatsing in de Staatscourant.\n3 De toezichthouder is bevoegd, met medeneming van de benodigde apparatuur, een woning binnen te treden zonder toestemming van de bewoner.\n4 De toezichthouder is voorts bevoegd te allen tijde ter zake van een arbeidsongeval een onderzoek in te stellen. Hij stelt naar aanleiding van dat onderzoek een rapport op.\n5 De toezichthouder stelt ter voldoening aan artikel 5:18, zesde lid, van de Algemene wet bestuursrecht een rapport op; dit rapport en een rapport als bedoeld in het vierde lid zendt hij aan de werkgever, aan de ondernemingsraad of aan de personeelsvertegenwoordiging, en indien van toepassing, aan de bij een arbeidsongeval betrokken persoon of personen.\n6 De toezichthouder is bevoegd bij het verwerken van persoonsgegevens gebruik te maken van het burgerservicenummer voorzover dat voor de vervulling van zijn taak redelijkerwijs nodig is.\n7 De toezichthouder geeft zo spoedig mogelijk gehoor aan het verzoek om een onderzoek in te stellen, gedaan door de ondernemingsraad of de personeelsvertegenwoordiging, dan wel door een vereniging van werknemers, die krachtens haar statuten ten doel heeft de belangen van haar leden als werknemers te behartigen en als zodanig in de betrokken onderneming of bedrijfstak werkzaam is en in het bezit is van volledige rechtsbevoegdheid.\n8 Ten dienste van het onderzoek naar een overtreding is de toezichthouder, voor zover dat voor de vervulling van zijn taak redelijkerwijs nodig is, bevoegd ieder staande te houden en te vorderen dat hij zijn naam, voornamen, geboortedatum en geboortejaar en adres opgeeft.\n9 Bij of krachtens algemene maatregel van bestuur kan worden bepaald dat in de bij of krachtens die maatregel te bepalen gevallen en wijze degene die arbeid verricht of doet verrichten in de territoriale zee of de exclusieve economische zone, verplicht is de toezichthouder bij de uitoefening van zijn bevoegdheden te vervoeren naar door de toezichthouder aan te duiden plaatsen waar deze arbeid wordt of zal worden verricht.\n10 Gelet op artikel 9, tweede lid, onderdeel b, van de Algemene verordening gegevensbescherming, is het verbod om gegevens over gezondheid te verwerken niet van toepassing indien de verwerking geschiedt door de toezichthouder, voor zover de verwerking noodzakelijk is voor het onderzoek naar arbeidsongevallen die leiden tot de dood, een blijvend letsel of een ziekenhuisopname als bedoeld in artikel 9, eerste lid .\n11 Indien toepassing wordt gegeven aan het tiende lid worden de gegevens over gezondheid alleen verwerkt door personen die uit hoofde van ambt, beroep of wettelijk voorschrift dan wel krachtens een overeenkomst tot geheimhouding zijn verplicht.",
+              "whs_topics": [
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "health_surveillance",
+                  "relevance": "medium",
+                  "match_count": 2
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 2
+                },
+                {
+                  "id": "ppe",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "incident_reporting",
+                  "relevance": "high",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
+                "score": 2,
+                "level": "medium",
                 "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "medium_keyword_matches": 2
               },
               "paragraphs": []
             },
@@ -649,8 +1045,14 @@
               "id": "ce623a91071ccae9",
               "number": "25",
               "title": "Artikel 25. Toezicht op instellingen",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "Onze Minister ziet toe op de rechtmatige en doeltreffende uitvoering van het bepaalde bij en krachtens deze wet door krachtens artikel 20, tweede lid , aangewezen instellingen.",
+              "whs_topics": [
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
                 "score": 2,
                 "level": "medium",
@@ -663,8 +1065,24 @@
               "id": "e8088b010a22443d",
               "number": "26",
               "title": "Artikel 26. Geheimhouding",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "De toezichthouders zijn, behoudens tegenover hen aan wier gezag zij uit kracht van hun ambt zijn onderworpen, verplicht tot geheimhouding van de namen van de personen door wie een klacht is ingediend of aangifte is gedaan van een overtreding van deze wet en de daarop berustende bepalingen, behoudens wanneer deze personen hun schriftelijk hebben verklaard tegen de mededeling van hun namen geen bedenkingen te hebben.",
+              "whs_topics": [
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "documentation",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "penalties",
+                  "relevance": "high",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
                 "score": 0,
                 "level": "low",
@@ -677,8 +1095,24 @@
               "id": "e58c19ea316c4a18",
               "number": "27",
               "title": "Artikel 27. Eis tot naleving",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "1 Een daartoe aangewezen toezichthouder kan aan een werkgever een eis stellen betreffende de wijze waarop een of meer bepalingen gesteld bij of krachtens deze wet moeten worden nageleefd.\n2 Een eis vermeldt van welke regelen hij de wijze van naleving bepaalt en bevat de termijn waarbinnen eraan moet zijn voldaan.\n3 De werkgever is verplicht om aan de eis te voldoen. De werknemers zijn verplicht aan de eis te voldoen voor zover zulks bij de eis is bepaald. De werkgever draagt zorg dat de werknemers van de op hen rustende verplichting zo spoedig mogelijk in kennis worden gesteld.\n4 Voor de toepassing van de vorige leden worden met een werkgever gelijkgesteld: de in artikel 16, zevende, achtste en negende lid , bedoelde personen voor zover het betreft de krachtens dat artikel omschreven verplichtingen.\n5 Een eis kan worden gesteld tot naleving van de artikelen 3 , 4 , 5 , 6 , 8 , 11 , 13, eerste lid, eerste volzin, en tweede tot en met vierde lid, zevende lid, onder b, negende en tiende lid , 14, eerste lid, tweede lid, onder a tot en met f, vierde en vijfde lid , 14a, tweede, derde en vierde lid , 15, eerste en derde lid , 16 , voor zover dat bij de krachtens dat artikel gestelde regels is bepaald, 18 en 19 .\n6 Een eis kan worden gesteld tot naleving van artikel 14, tweede lid, onder g, h en j , waarbij voor de toepassing van het eerste tot en met derde lid de bedrijfsarts met de werkgever gelijk wordt gesteld en tot naleving van artikel 14, tweede lid, onder i, waarbij voor de toepassing van het eerste tot en met derde lid de in artikel 14, eerste lid , bedoelde personen met de werkgever gelijk worden gesteld.",
+              "whs_topics": [
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "prevention_services",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
                 "score": 0,
                 "level": "low",
@@ -691,13 +1125,39 @@
               "id": "d3d7f01e2b0db301",
               "number": "28",
               "title": "Artikel 28. Stillegging van het werk",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "1 Een daartoe aangewezen toezichthouder is bevoegd mondeling of bij gedagtekend schrijven te bevelen, dat personen niet mogen blijven in door hem aangewezen plaatsen, of dat door hem aangewezen werkzaamheden worden gestaakt dan wel niet mogen worden aangevangen, indien naar zijn redelijk oordeel dat verblijf of die werkzaamheden ernstig gevaar opleveren voor personen.\n2 Een mondeling bevel wordt zo spoedig mogelijk schriftelijk bevestigd aan de werkgever of aan de andere personen, bedoeld in artikel 16, zevende, achtste en negende lid .\n3 De bevoegdheid, bedoeld in het eerste lid, geldt mede in die gevallen, waarin op grond van het bepaalde in artikel 27 aan een gestelde eis nog geen uitvoering behoeft te worden gegeven.\n4 Zodra naar het oordeel van de toezichthouder die een bevel als bedoeld in het eerste lid gaf, geen ernstig gevaar meer aanwezig is, trekt hij het bevel in.\n5 De toezichthouder, die een bevel als bedoeld in het eerste lid gegeven heeft, is bevoegd met betrekking tot dit bevel de nodige maatregelen te treffen, de nodige aanwijzingen te geven en de hulp van de sterke arm in te roepen. De maatregelen en aanwijzingen kunnen onder meer betrekking hebben op het verzegelen van arbeidsmiddelen en arbeidsplaatsen.\n6 Ieder wie zulks aangaat is verplicht zich te gedragen overeenkomstig een bevel, als bedoeld in het eerste lid en een aanwijzing als bedoeld in het vijfde lid.\n7 De bevoegdheden uit het eerste tot en met zesde lid zijn van overeenkomstige toepassing indien in verband met de epidemie van een infectieziekte behorend tot groep A1 of een directe dreiging daarvan als bedoeld in de Wet publieke gezondheid , bij of krachtens wettelijk voorschrift dan wel gezien de stand van de wetenschap en professionele dienstverlening benodigde noodzakelijke maatregelen of voorzieningen die de kans op besmetting van werknemers of derden op arbeidsplaatsen kunnen voorkomen of beperken, in ernstige mate niet worden getroffen.",
+              "whs_topics": [
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "risk_assessment",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "documentation",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "work_equipment",
+                  "relevance": "high",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "score": 4,
+                "level": "high",
+                "high_keyword_matches": 1,
+                "medium_keyword_matches": 2
               },
               "paragraphs": []
             },
@@ -705,12 +1165,28 @@
               "id": "7fcf836c43155620",
               "number": "28a",
               "title": "Artikel 28a. Bevel stillegging van werk in verband met recidive",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "1 Een daartoe door Onze Minister aangewezen, onder hem ressorterende ambtenaar kan, nadat een overtreding van een voorschrift of verbod bij of krachtens deze wet is geconstateerd die bestuurlijk beboetbaar is gesteld of op grond van de Wet op de economische delicten strafbaar is gesteld, aan de werkgever of de zelfstandige een schriftelijke waarschuwing geven dat bij herhaling van de overtreding of bij een latere overtreding van eenzelfde in de waarschuwing aangegeven wettelijke verplichting of verbod of bij of krachtens algemene maatregel van bestuur aan te wijzen soortgelijke verplichtingen of verboden, door hem een bevel kan worden opgelegd dat door hem aangewezen werkzaamheden voor ten hoogste drie maanden worden gestaakt dan wel niet mogen worden aangevangen. De artikelen 24, tweede lid , en 27, vierde lid , zijn van overeenkomstige toepassing.\n2 Indien een waarschuwing als bedoeld in het eerste lid is gegeven en herhaling van de overtreding of een latere overtreding als bedoeld in het eerste lid is geconstateerd, kan door de ambtenaar, bedoeld in het eerste lid, aan de werkgever of de zelfstandige bij beschikking een bevel als bedoeld in het eerste lid worden opgelegd dat wordt opgevolgd met ingang van het in de beschikking aangeven tijdstip. Deze beschikking wordt niet gegeven zolang wegens de eerste overtreding, bedoeld in het eerste lid, nog niet een bestuurlijke boete is opgelegd of een proces-verbaal is opgemaakt.\n3 De constatering van de overtreding, bedoeld in het eerste of tweede lid, wordt vastgelegd in een boeterapport of proces-verbaal.\n4 De waarschuwing, bedoeld in het eerste lid, vervalt indien na de dagtekening van de waarschuwing vijf jaren zijn verstreken.\n5 De ambtenaar, bedoeld in het eerste lid, is bevoegd met betrekking tot het bevel, bedoeld in het tweede lid, de nodige maatregelen te treffen, de nodige aanwijzingen te geven en de hulp van de sterke arm in te roepen.\n6 Ieder wie zulks aangaat is verplicht zich te gedragen overeenkomstig een bevel als bedoeld in het tweede lid en een maatregel of aanwijzing als bedoeld in het vijfde lid.\n7 Bij of krachtens algemene maatregel van bestuur worden nadere regels gesteld met betrekking tot het eerste en tweede lid.",
+              "whs_topics": [
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "penalties",
+                  "relevance": "high",
+                  "match_count": 3
+                },
+                {
+                  "id": "documentation",
+                  "relevance": "high",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
+                "score": 2,
+                "level": "medium",
+                "high_keyword_matches": 1,
                 "medium_keyword_matches": 0
               },
               "paragraphs": []
@@ -719,7 +1195,7 @@
               "id": "25f7b23d1ef57469",
               "number": "28b",
               "title": "Artikel 28b. Last onder bestuursdwang",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "Onze Minister is bevoegd tot oplegging van een last onder bestuursdwang ter zake van de naleving van de artikelen 24, negende lid , 28, eerste lid , en 28a, tweede lid , en de daartoe bij algemene maatregel van bestuur aangewezen bepalingen krachtens deze wet. Artikel 24, tweede lid, is van overeenkomstige toepassing.",
               "whs_topics": [],
               "amazon_logistics_relevance": {
                 "score": 0,
@@ -733,13 +1209,34 @@
               "id": "8de8e0360ced54f6",
               "number": "29",
               "title": "Artikel 29. Werkonderbreking",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "1 Een werknemer is bevoegd het werk te onderbreken en de onderbreking voort te zetten, indien en zolang naar zijn redelijk oordeel ernstig gevaar voor personen als bedoeld in artikel 28 aanwezig is en naar zijn redelijk oordeel het gevaar zo onmiddellijk dreigt dat een toezichthouder niet tijdig kan optreden. Voor de duur van de onderbreking behoudt de werknemer zijn aanspraak op het naar tijdruimte vastgesteld loon. De werknemer mag als gevolg van de werkonderbreking niet worden benadeeld in zijn positie in het bedrijf of in de inrichting.\n2 Degene die stelt dat de werknemer de aanwezigheid van onmiddellijk dreigend gevaar als bedoeld in het eerste lid op grond van de feiten waarop hij zich beroept, niet naar zijn redelijk oordeel mocht aannemen, moet dit bewijzen.\n3 Indien de onderbreking van het werk geschiedt buiten weten van de werkgever onderscheidenlijk de bij de arbeid betrokken leidinggevende persoon, moet de werknemer de onderbreking terstond bij deze melden.\n4 De onderbreking van het werk wordt zo spoedig mogelijk ter kennis gebracht van de daartoe aangewezen toezichthouder, die een bevel geeft krachtens artikel 28, eerste lid , of verklaart, zo nodig onder het stellen van een eis als bedoeld in artikel 27 , dat de arbeid kan worden verricht. Door de beschikking van de daartoe aangewezen toezichthouder eindigt de bevoegdheid van de werknemer de werkonderbreking voort te zetten.",
+              "whs_topics": [
+                {
+                  "id": "risk_assessment",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
+                "score": 1,
+                "level": "medium",
                 "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "medium_keyword_matches": 1
               },
               "paragraphs": []
             },
@@ -747,12 +1244,23 @@
               "id": "55e8db39f170893b",
               "number": "29a",
               "title": "Artikel 29a. Gegevensuitwisseling",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "1 Bestuursorganen en een instelling als bedoeld in artikel 20, tweede lid , zijn bevoegd uit eigen beweging en verplicht desgevraagd aan Onze Minister en de toezichthouder kosteloos alle gegevens en inlichtingen te verstrekken die noodzakelijk zijn voor de uitvoering en het toezicht op de naleving van het bepaalde bij of krachtens deze wet en dit noodzakelijk is ten behoeve van een samenwerkingsverband tussen twee of meer van de voornoemde instanties.\n2 Onze Minister en de toezichthouder verstrekken andere bestuursorganen en een instelling als bedoeld in artikel 20, tweede lid , kosteloos alle gegevens en inlichtingen, die zijn verkregen door de uitvoering of het toezicht op de naleving van het bepaalde bij of krachtens deze wet, welke noodzakelijk zijn voor de uitvoering van hun wettelijke taak en dit noodzakelijk is ten behoeve van een samenwerkingsverband tussen twee of meer van de voornoemde instanties.\n3 Onze Minister, bestuursorganen, de toezichthouder en een instelling als bedoeld in artikel 20, tweede lid , kunnen bij het verwerken van persoonsgegevens gebruik maken van het burgerservicenummer.\n4 De gegevensverstrekking, bedoeld in het eerste en tweede lid, vindt niet plaats indien de persoonlijke levenssfeer van de betrokkene daardoor onevenredig wordt geschaad.\n5 Bij of krachtens algemene maatregel van bestuur kunnen regels worden gesteld omtrent de gevallen waarin en de wijze waarop in ieder geval gegevens worden verstrekt.",
+              "whs_topics": [
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "ppe",
+                  "relevance": "high",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
+                "score": 2,
+                "level": "medium",
+                "high_keyword_matches": 1,
                 "medium_keyword_matches": 0
               },
               "paragraphs": []
@@ -761,7 +1269,7 @@
               "id": "40934318ae3a497c",
               "number": "29b",
               "title": "Artikel 29b. Openbaarmaking van door toezicht op de naleving verkregen gegevens",
-              "text": "... Sla het regelingonderdeel op\n\n[Tekst zonder datum inwerkingtreding. Zie het wijzigingenoverzicht .]",
+              "text": "Dit onderdeel is (nog) niet in werking getreden; zie het .",
               "whs_topics": [],
               "amazon_logistics_relevance": {
                 "score": 0,
@@ -783,8 +1291,14 @@
               "id": "1be661c157895fe6",
               "number": "30",
               "title": "Artikel 30. Vrijstelling en ontheffing",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "1 Onze Minister kan met betrekking tot categorieën van bedrijven, inrichtingen, personen, of arbeidsverhoudingen vrijstelling verlenen van de voorschriften zoals die bij of krachtens de artikelen 5 , 12 tot en met 18 en 20 zijn vastgesteld.\n2 Een daartoe aangewezen toezichthouder kan met betrekking tot een individueel bedrijf of inrichting ontheffing verlenen van de in het eerste lid bedoelde voorschriften, tenzij met betrekking tot een dergelijk voorschrift een eis is gesteld.\n3 Bij algemene maatregel van bestuur kunnen regelen worden gesteld inzake het verlenen van vrijstellingen of ontheffingen als bedoeld in het eerste onderscheidenlijk tweede lid.\n4 Een vrijstelling of een ontheffing kan onder beperkingen worden verleend.\n5 Aan een vrijstelling of een ontheffing kunnen voorschriften worden verbonden.\n6 Een vrijstelling onderscheidenlijk ontheffing kan worden ingetrokken wanneer: a. een of meer der redenen waarom zij is verleend is of zijn vervallen; b. een of meer van de daaraan verbonden voorschriften niet wordt of worden nageleefd; c. zich na de verlening zodanige feiten of omstandigheden voordoen dat, indien deze ten tijde van de verlening bekend waren geweest, de vrijstelling of ontheffing niet of niet in die vorm zou zijn verleend.\n6 Een vrijstelling onderscheidenlijk ontheffing kan worden ingetrokken wanneer:\na. een of meer der redenen waarom zij is verleend is of zijn vervallen;\nb. een of meer van de daaraan verbonden voorschriften niet wordt of worden nageleefd;\nc. zich na de verlening zodanige feiten of omstandigheden voordoen dat, indien deze ten tijde van de verlening bekend waren geweest, de vrijstelling of ontheffing niet of niet in die vorm zou zijn verleend.",
+              "whs_topics": [
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 2
+                }
+              ],
               "amazon_logistics_relevance": {
                 "score": 2,
                 "level": "medium",
@@ -797,7 +1311,7 @@
               "id": "06a586a406f2d643",
               "number": "31",
               "title": "Artikel 31. Beroep",
-              "text": "... Sla het regelingonderdeel op\n\n[Wijziging(en) zonder datum inwerkingtreding aanwezig. Zie het wijzigingenoverzicht .]",
+              "text": "1 Tegen een beschikking op grond van deze wet van een ambtenaar als bedoeld in artikel 24, tweede lid , kan door een belanghebbende administratief beroep worden ingesteld bij Onze Minister, tenzij sprake is van een beschikking die blijkens het tweede lid namens Onze Minister wordt gegeven.\n2 Een beschikking op grond van deze wet van een ambtenaar als bedoeld in de artikelen 24, eerste lid , 28a, eerste lid , 28b , en 34, eerste lid , wordt gegeven namens Onze Minister.",
               "whs_topics": [],
               "amazon_logistics_relevance": {
                 "score": 0,
@@ -819,19 +1333,39 @@
               "id": "f12e03ab6b496d49",
               "number": "32",
               "title": "Artikel 32. Strafbepaling",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "Het is de werkgever verboden handelingen te verrichten of na te laten in strijd met deze wet of de daarop berustende bepalingen indien daardoor, naar hij weet of redelijkerwijs moet weten, levensgevaar of ernstige schade aan de gezondheid van een of meer werknemers ontstaat of te verwachten is.",
               "whs_topics": [
+                {
+                  "id": "risk_assessment",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 1
+                },
                 {
                   "id": "penalties",
                   "relevance": "high",
                   "match_count": 1
+                },
+                {
+                  "id": "health_surveillance",
+                  "relevance": "medium",
+                  "match_count": 1
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 1
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
+                "score": 1,
+                "level": "medium",
                 "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "medium_keyword_matches": 1
               },
               "paragraphs": []
             },
@@ -839,28 +1373,14 @@
               "id": "c32f89050e636cc3",
               "number": "33",
               "title": "Artikel 33. Overtredingen",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 Als overtreding wordt aangemerkt het niet naleven van de artikelen 3 , 4, eerste lid , 5 , 6, eerste lid, eerste volzin , 8 , 9, eerste en tweede lid , 10 , 11 , 13, eerste lid, eerste volzin, en tweede tot en met vierde lid, zevende lid, onder b, negende en tiende lid , 14, eerste lid, tweede lid, onder a tot en met f, derde lid, tweede zin, vierde en vijfde lid , 14a, tweede en derde lid , 15, eerste en derde lid , 18 en 19 .\n2 Als overtreding wordt tevens aangemerkt het niet naleven van de artikelen 6, eerste lid, tweede volzin , en 16, tiende lid , voor zover het niet naleven van de in die artikelleden bedoelde voorschriften en verboden bij of krachtens algemene maatregel van bestuur is aangemerkt als overtreding.\n3 Geen bestuurlijke boete kan worden opgelegd ter zake van bij of krachtens deze wet strafbaar gestelde feiten of ter zake van deze wet in de Wet op de economische delicten strafbaar gestelde feiten, met uitzondering van de strafbare feiten, bedoeld in artikel 6, derde lid , van deze wet en artikel 1, onder 1°, van de Wet op de economische delicten ten aanzien van artikel 6, eerste lid, eerste volzin.",
               "whs_topics": [
                 {
                   "id": "penalties",
                   "relevance": "high",
-                  "match_count": 1
+                  "match_count": 3
                 }
               ],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "52b49ce265e5157b",
-              "number": "33a",
-              "title": "Artikel 33a. a",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-07-2009]",
-              "whs_topics": [],
               "amazon_logistics_relevance": {
                 "score": 0,
                 "level": "low",
@@ -873,32 +1393,28 @@
               "id": "a3cee359c40a2fba",
               "number": "34",
               "title": "Artikel 34. Hoogte bestuurlijke boete en recidive",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 Een daartoe door Onze Minister aangewezen, onder hem ressorterende ambtenaar legt de bestuurlijke boete op aan de overtreder op wie de verplichtingen rusten die voortvloeien uit deze wet en de daarop berustende bepalingen, voor zover het niet naleven daarvan is aangeduid als overtreding.\n2 De ambtenaar, bedoeld in het eerste lid, is niet reeds aangewezen als toezichthouder.\n3 De bestuurlijke boete die voor een overtreding kan worden opgelegd bedraagt ten hoogste het bedrag van de vijfde categorie, bedoeld in artikel 23, vierde lid, van het Wetboek van Strafrecht .\n4 De bestuurlijke boete die voor een overtreding van artikel 6, eerste lid , of voor het niet naleven van een voorschrift of verbod bij of krachtens de algemene maatregel van bestuur, bedoeld in artikel 6, eerste lid, voor zover aangemerkt als overtreding, kan worden opgelegd bedraagt ten hoogste het bedrag van de zesde categorie, bedoeld in artikel 23, vierde lid, van het Wetboek van Strafrecht .\n5 Onverminderd het derde en vierde lid verhoogt de op grond van het eerste lid aangewezen ambtenaar de op te leggen bestuurlijke boete met 100 procent van het boetebedrag, vastgesteld op grond van het tiende lid, indien binnen een tijdvak van vijf jaar voorafgaand aan de dag van constatering van de overtreding een eerdere overtreding, bestaande uit het niet naleven van eenzelfde wettelijke verplichting of verbod of het niet naleven van bij of krachtens algemene maatregel van bestuur aan te wijzen soortgelijke verplichtingen en verboden, is geconstateerd en de bestuurlijke boete wegens de eerdere overtreding onherroepelijk is geworden.\n6 De verhoging van de bestuurlijke boete, bedoeld in het vijfde lid, bedraagt 200 procent indien zowel de overtreding als de eerdere overtreding, bedoeld in dat lid, bij of krachtens algemene maatregel van bestuur zijn aangewezen als ernstige overtredingen.\n7 Onverminderd het derde en vierde lid verhoogt de op grond van het eerste lid aangewezen ambtenaar de op te leggen bestuurlijke boete met 200 procent van het boetebedrag, vastgesteld op grond van het tiende lid, indien binnen een tijdvak van vijf jaar voorafgaand aan de dag van constatering van de overtreding twee maal een eerdere overtreding, bestaande uit het niet naleven van eenzelfde wettelijke verplichting of verbod of het niet naleven van bij of krachtens algemene maatregel van bestuur aan te wijzen soortgelijke verplichtingen en verboden, is geconstateerd en de bestuurlijke boeten wegens de eerdere overtredingen onherroepelijk zijn geworden.\n8 Voor de toepassing van het vijfde en zevende lid wordt met een onherroepelijke bestuurlijke boete gelijkgesteld een onherroepelijke strafrechtelijke sanctie wegens een overtreding als bedoeld in artikel 6, derde lid .\n9 In afwijking van het vijfde en zevende lid is het tijdvak van vijf jaar in die leden tien jaar indien de onherroepelijke boetes, bedoeld in die leden, zijn opgelegd wegens bij of krachtens algemene maatregel van bestuur aangewezen ernstige overtredingen.\n10 Onze Minister stelt beleidsregels vast waarin de boetebedragen voor de overtredingen worden vastgesteld. Artikel 5:53 van de Algemene wet bestuursrecht is van toepassing indien een artikel gesteld bij of krachtens deze wet op grond waarvan een bestuurlijke boete kan worden opgelegd, niet is nageleefd.\n11 In afwijking van artikel 8:69 van de Algemene wet bestuursrecht kan de rechter in beroep of hoger beroep de hoogte van de boete ook ten nadele van de belanghebbende wijzigen.",
               "whs_topics": [
                 {
                   "id": "penalties",
                   "relevance": "high",
+                  "match_count": 4
+                },
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
                   "match_count": 1
                 }
               ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "f0bd18d5c711252c",
-              "number": "35",
-              "title": "Artikel 35. 5",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-07-2009]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
+                "score": 2,
+                "level": "medium",
+                "high_keyword_matches": 1,
                 "medium_keyword_matches": 0
               },
               "paragraphs": []
@@ -907,11 +1423,16 @@
               "id": "692b9ed930c398ac",
               "number": "36",
               "title": "Artikel 36. Boeterapport",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "1 Onverminderd artikel 5:48, tweede lid, van de Algemene wet bestuursrecht vermeldt het rapport naast de overtreder in ieder geval de andere bij de overtreding betrokken persoon of personen.\n2 Het rapport wordt toegezonden aan de daartoe op grond van artikel 34, eerste lid , aangewezen ambtenaar.\n3 Een afschrift van het rapport wordt toegezonden of uitgereikt aan de andere bij de overtreding betrokken persoon of personen, bedoeld in het eerste lid.",
               "whs_topics": [
                 {
                   "id": "penalties",
                   "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
                   "match_count": 1
                 }
               ],
@@ -927,12 +1448,12 @@
               "id": "899189f58b2d3e3b",
               "number": "37",
               "title": "Artikel 37. Boetebeschikking",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "Een afschrift van de boetebeschikking wordt toegezonden of uitgereikt aan de andere bij de overtreding betrokken persoon of personen, bedoeld in artikel 36, eerste lid , en in voorkomend geval, desgevraagd aan zijn of hun nabestaande of nabestaanden.",
               "whs_topics": [
                 {
                   "id": "penalties",
                   "relevance": "high",
-                  "match_count": 1
+                  "match_count": 2
                 }
               ],
               "amazon_logistics_relevance": {
@@ -947,12 +1468,12 @@
               "id": "5dfbb1ae57ab90b7",
               "number": "38",
               "title": "Artikel 38. Inlichtingenplicht jegens de boeteoplegger",
-              "text": "... Sla het regelingonderdeel op",
+              "text": "Degene aan wie een bestuurlijke boete is opgelegd is verplicht desgevraagd aan de daartoe op grond van artikel 34, eerste lid , aangewezen ambtenaar de inlichtingen te verstrekken die voor de tenuitvoerlegging van de boete van belang zijn.",
               "whs_topics": [
                 {
                   "id": "employer_obligations",
                   "relevance": "high",
-                  "match_count": 1
+                  "match_count": 2
                 },
                 {
                   "id": "penalties",
@@ -969,67 +1490,22 @@
               "paragraphs": []
             },
             {
-              "id": "a950ed95f372f929",
-              "number": "39",
-              "title": "Artikel 39. 9",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-07-2009]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "9a3dca1a4bd2cdb2",
-              "number": "40",
-              "title": "Artikel 40. 0",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-04-2011]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "20533ced4c5e0769",
-              "number": "41",
-              "title": "Artikel 41. 1",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-07-2009]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "0c672a8c78051581",
-              "number": "42",
-              "title": "Artikel 42. 2",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2013]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
               "id": "3c2348da21643bef",
               "number": "43",
               "title": "Artikel 43. Terugbetaling",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "Indien een bestuurlijke boete ten onrechte is opgelegd, wordt deze binnen zes weken nadat is vastgesteld dat de bestuurlijke boete ten onrechte is opgelegd, aan de rechthebbende terugbetaald.",
+              "whs_topics": [
+                {
+                  "id": "penalties",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
                 "score": 2,
                 "level": "medium",
@@ -1050,8 +1526,14 @@
               "id": "ad0ddcfbd5863fb3",
               "number": "44",
               "title": "Artikel 44. Kosten",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "De kosten die zijn verbonden aan de naleving van de regels die bij of krachtens deze wet zijn gesteld, worden niet ten laste van de werknemers gebracht.",
+              "whs_topics": [
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
                 "score": 0,
                 "level": "low",
@@ -1064,13 +1546,39 @@
               "id": "cd92cd3b084877d4",
               "number": "45",
               "title": "Artikel 45. Overgangsbepaling",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
+              "text": "Op schriftelijke afspraken die zijn gemaakt overeenkomstig artikel 14, vierde lid , zoals dat artikellid luidde de dag voorafgaand aan het tijdstip van inwerkingtreding van de Wet van 25 januari 2017 tot wijziging van de Arbeidsomstandighedenwet in verband met de versterking van de betrokkenheid van de werkgevers en werknemers bij de arbodienstverlening, de preventie in het bedrijf of de inrichting van de werkgever, en de randvoorwaarden voor het handelen van de bedrijfsarts (Stb. 2017, 22), blijft artikel 14, vierde lid, zoals dat artikellid luidde de dag voorafgaand aan het tijdstip van inwerkingtreding van die wet, van toepassing tot de datum waarop die afspraken expireren, doch uiterlijk tot een jaar na inwerkingtreding van die wet. Tot dat tijdstip is artikel 14, vijfde lid , niet van toepassing.",
+              "whs_topics": [
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "prevention_services",
+                  "relevance": "high",
+                  "match_count": 2
+                },
+                {
+                  "id": "documentation",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employer_obligations",
+                  "relevance": "high",
+                  "match_count": 1
+                },
+                {
+                  "id": "employee_rights",
+                  "relevance": "medium",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
+                "score": 1,
+                "level": "medium",
                 "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
+                "medium_keyword_matches": 1
               },
               "paragraphs": []
             },
@@ -1078,274 +1586,14 @@
               "id": "5a4e4ba43b03643c",
               "number": "46",
               "title": "Artikel 46. Citeertitel",
-              "text": "... Sla het regelingonderdeel op",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "25ce789938aadbe4",
-              "number": "47",
-              "title": "Artikel 47. 7",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "b8df87555bc3d2fe",
-              "number": "49",
-              "title": "Artikel 49. 9",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "fa92a6dc5232ed14",
-              "number": "50",
-              "title": "Artikel 50. 0",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "be58eeaa5f04b138",
-              "number": "51",
-              "title": "Artikel 51. 1",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "1135cdfb75537976",
-              "number": "52",
-              "title": "Artikel 52. 2",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "0613ca5944e369d8",
-              "number": "53",
-              "title": "Artikel 53. 3",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-05-2004]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "2898c32271b2b09c",
-              "number": "54",
-              "title": "Artikel 54. 4",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 29-12-2000]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "fd7c18f7f71dd9c2",
-              "number": "55",
-              "title": "Artikel 55. 5",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "ad4bf34b954a636d",
-              "number": "56",
-              "title": "Artikel 56. 6",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "17cad480c5001d7a",
-              "number": "57",
-              "title": "Artikel 57. 7",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "8009456ba1993242",
-              "number": "58",
-              "title": "Artikel 58. 8",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "5628e96b2a3c4106",
-              "number": "59",
-              "title": "Artikel 59. 9",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "f3ced159d7f2d4b8",
-              "number": "60",
-              "title": "Artikel 60. 0",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "d192647868745a4b",
-              "number": "61",
-              "title": "Artikel 61. 1",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "175d84faf0af45b1",
-              "number": "62",
-              "title": "Artikel 62. 2",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "cc83af693ac3bb7b",
-              "number": "63",
-              "title": "Artikel 63. 3",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "0750b0e465a9d08f",
-              "number": "64",
-              "title": "Artikel 64. 4",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "fc0c4ab4bc8e6238",
-              "number": "65",
-              "title": "Artikel 65. 5",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
-              "amazon_logistics_relevance": {
-                "score": 0,
-                "level": "low",
-                "high_keyword_matches": 0,
-                "medium_keyword_matches": 0
-              },
-              "paragraphs": []
-            },
-            {
-              "id": "f577fbe273e372d5",
-              "number": "66",
-              "title": "Artikel 66. 6",
-              "text": "... Sla het regelingonderdeel op\n\n[Vervallen per 01-01-2007]",
-              "whs_topics": [],
+              "text": "Deze wet wordt aangehaald als: Arbeidsomstandighedenwet.",
+              "whs_topics": [
+                {
+                  "id": "workplace_design",
+                  "relevance": "high",
+                  "match_count": 1
+                }
+              ],
               "amazon_logistics_relevance": {
                 "score": 0,
                 "level": "low",


### PR DESCRIPTION
The Dutch law scraper was only capturing UI boilerplate instead of actual law content. The issue was that wetten.overheid.nl uses a specific HTML structure where article content is in `ul.artikel_leden > p.lid` elements, separate from the h4 headers.

Changes:
- Updated NLScraper._parse_dutch_law_full() to find div.artikel containers by ID pattern (Hoofdstuk*_Artikel*)
- Extract content from ul.artikel_leden elements containing p.lid paragraphs
- Added support for p.al (sub-definitions) and p.labeled elements
- Added fallback extraction for containers without standard classes
- Extended boilerplate patterns to filter more UI elements

Results: Article 1 now contains 8,518 chars of definitions vs ~50 chars of boilerplate previously. Total of 47 articles scraped with full content.