### PR TITLE
Fix scraping errors and update sources table

### DIFF
--- a/eu_safety_laws/custom_sources.json
+++ b/eu_safety_laws/custom_sources.json
@@ -59,7 +59,7 @@
     },
     "DE": {
       "DGUV Vorschrift 1": {
-        "url": "https://www.dguv.de/publikationen/vorschriften-regeln-informationen/vorschriften/dguv-vorschrift-1/index.jsp",
+        "url": "https://publikationen.dguv.de/regelwerk/dguv-vorschriften/2909/dguv-vorschrift-1",
         "name": "Grundsätze der Prävention",
         "description": "This regulation outlines the fundamental principles of prevention for occupational safety and health in Germany. While issued by the DGUV (German Social Accident Insurance), it is based on and implements statutory requirements and is crucial for workplace safety. It covers responsibilities of employers and employees and establishes the framework for risk assessments and preventive measures.",
         "enabled": true,
@@ -67,12 +67,14 @@
         "source_type": "custom"
       },
       "BildscharbV": {
-        "url": "https://www.gesetze-im-internet.de/bildscharbv/",
-        "name": "Verordnung über Sicherheit und Gesundheitsschutz bei der Arbeit an Bildschirmgeräten",
-        "description": "This regulation (Bildschirmarbeitsverordnung) specifically addresses the safety and health protection of employees working with display screen equipment (VDTs). It covers ergonomic requirements, workstation design, breaks, and eye exams.",
-        "enabled": true,
+        "url": "https://www.gesetze-im-internet.de/arbst_ttv_2004/",
+        "name": "Bildschirmarbeitsverordnung (repealed - now in ArbStättV Anhang 6)",
+        "description": "The Bildschirmarbeitsverordnung was repealed in 2016. Its contents were transferred to Appendix 6 (Anhang 6) of the Arbeitsstättenverordnung (ArbStättV). Since July 2024, ASR A6 'Bildschirmarbeit' provides additional technical specifications.",
+        "enabled": false,
         "created_at": "2025-12-18T01:18:07.386751",
-        "source_type": "custom"
+        "source_type": "custom",
+        "repealed": true,
+        "repealed_note": "Integrated into ArbStättV Anhang 6 since 2016"
       },
       "TRBS 1111": {
         "url": "https://www.baua.de/DE/Angebote/Regelwerk/TRBS/pdf/TRBS-1111.pdf?__blob=publicationFile&v=8",

--- a/eu_safety_laws/discovered_sources.json
+++ b/eu_safety_laws/discovered_sources.json
@@ -4,7 +4,7 @@
   "sources": [
     {
       "name": "Arbeitsschutzgesetz (ArbSchG)",
-      "url": "https://www.gesetze-im-internet.de/arbshg/index.html",
+      "url": "https://www.gesetze-im-internet.de/arbschg/",
       "country": "DE",
       "language": "de",
       "source_type": "law",
@@ -18,7 +18,7 @@
     },
     {
       "name": "Arbeitsstättenverordnung (ArbStättV)",
-      "url": "https://www.gesetze-im-internet.de/arbstättv/index.html",
+      "url": "https://www.gesetze-im-internet.de/arbst_ttv_2004/",
       "country": "DE",
       "language": "de",
       "source_type": "ordinance",
@@ -32,7 +32,7 @@
     },
     {
       "name": "Gefahrstoffverordnung (GefStoffV)",
-      "url": "https://www.gesetze-im-internet.de/gefstoffs জৈv/index.html",
+      "url": "https://www.gesetze-im-internet.de/gefstoffv_2010/",
       "country": "DE",
       "language": "de",
       "source_type": "ordinance",
@@ -46,7 +46,7 @@
     },
     {
       "name": "Betriebssicherheitsverordnung (BetrSichV)",
-      "url": "https://www.gesetze-im-internet.de/betrsichv/index.html",
+      "url": "https://www.gesetze-im-internet.de/betrsichv_2015/",
       "country": "DE",
       "language": "de",
       "source_type": "ordinance",


### PR DESCRIPTION
- Fix hardcoded BJNR identifier in _try_full_html_page() that was causing 404 errors for all laws except ArbSchG
- The method now dynamically extracts the correct BJNR from each law's main page HTML
- Update MuSchG path from /muschg/ to /muschg_2018/ in main_laws config
- Fix corrupted URLs in discovered_sources.json:
  - ArbSchG: /arbshg/ -> /arbschg/
  - ArbStättV: /arbstättv/index.html -> /arbst_ttv_2004/
  - GefStoffV: fixed Bengali character corruption
  - BetrSichV: /betrsichv/ -> /betrsichv_2015/
- Update DGUV Vorschrift 1 URL to new publikationen.dguv.de location
- Mark BildscharbV as repealed (integrated into ArbStättV since 2016)