### PR TITLE
Add multi-country scraping and PDF support

### DIFF
--- a/src/components/modules/LawBrowser.jsx
+++ b/src/components/modules/LawBrowser.jsx
@@ -10,6 +10,9 @@ import {
   isDatabaseLoaded,
   WHS_TOPIC_LABELS,
   RELEVANCE_LEVELS,
+  STRUCTURE_LABELS,
+  getStructureLabel,
+  DOC_TYPES,
   hasPdfSource,
   getPdfSourceUrl,
   isSupplementarySource
@@ -1907,7 +1910,9 @@ export function LawBrowser({ onBack }) {
 
                   return Object.entries(groupedSections).map(([chapterKey, { abschnitt, sections }]) => {
                     const isChapterExpanded = expandedChapters[chapterKey] ?? false
-                    const chapterTitle = abschnitt?.displayName || abschnitt?.title || `${chapterKey}. Abschnitt`
+                    // Use dynamic labels based on country/framework
+                    const groupingLabel = getStructureLabel(framework, 'grouping_1')
+                    const chapterTitle = abschnitt?.displayName || abschnitt?.title || `${chapterKey}. ${groupingLabel}`
 
                     return (
                       <div key={chapterKey} className="border-b border-gray-200 dark:border-whs-dark-600">
@@ -2037,6 +2042,19 @@ export function LawBrowser({ onBack }) {
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
                         </svg>
                       </button>
+                      {/* PDF Download Button */}
+                      {hasPdfSource(selectedLaw) && (
+                        <button
+                          onClick={() => openPdfModal(selectedLaw)}
+                          className="p-2 bg-white/10 hover:bg-white/20 rounded-lg transition-colors"
+                          title="View/Download Official PDF"
+                        >
+                          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 11v6m0 0l-2-2m2 2l2-2" />
+                          </svg>
+                        </button>
+                      )}
                       {selectedLaw.source?.url && (
                         <a
                           href={selectedLaw.source.url}
@@ -2155,7 +2173,7 @@ export function LawBrowser({ onBack }) {
                                   {showAbschnittHeader && section.abschnitt && (
                                     <div className="mb-6 mt-8 first:mt-0 p-4 bg-gradient-to-r from-whs-orange-50 to-transparent dark:from-whs-orange-900/20 dark:to-transparent rounded-lg border-l-4 border-whs-orange-500">
                                       <h2 className="text-xl font-bold text-gray-900 dark:text-white">
-                                        {section.abschnitt.displayName || `${section.abschnitt.number}. Abschnitt`}
+                                        {section.abschnitt.displayName || `${section.abschnitt.number}. ${getStructureLabel(framework, 'grouping_1')}`}
                                       </h2>
                                       <p className="text-gray-600 dark:text-gray-400 font-medium">
                                         {section.abschnitt.title}

--- a/src/services/euLawsDatabase.js
+++ b/src/services/euLawsDatabase.js
@@ -335,6 +335,52 @@ export const RELEVANCE_LEVELS = {
 }
 
 /**
+ * Country-specific structure labels for dynamic UI
+ * Used to display appropriate grouping labels based on the selected country/framework
+ */
+export const STRUCTURE_LABELS = {
+  'AT': {
+    grouping_1: 'Abschnitt',
+    grouping_2: 'Unterabschnitt',
+    article: '§',
+    section: 'Paragraph'
+  },
+  'DE': {
+    grouping_1: 'Abschnitt',  // or "Buch" for larger laws
+    grouping_2: 'Titel',
+    article: '§',
+    section: 'Paragraph'
+  },
+  'NL': {
+    grouping_1: 'Hoofdstuk',
+    grouping_2: 'Afdeling',
+    article: 'Artikel',
+    section: 'Artikel'
+  }
+}
+
+/**
+ * Get structure label for a country
+ * @param {string} country - Country code (AT, DE, NL)
+ * @param {string} level - Structure level ('grouping_1', 'grouping_2', 'article', 'section')
+ * @returns {string} - Localized label
+ */
+export function getStructureLabel(country, level = 'grouping_1') {
+  return STRUCTURE_LABELS[country]?.[level] || STRUCTURE_LABELS['DE'][level]
+}
+
+/**
+ * Document type enumeration for unified schema
+ */
+export const DOC_TYPES = {
+  LAW: 'law',
+  ORDINANCE: 'ordinance',
+  MERKBLATT: 'merkblatt',
+  GUIDELINE: 'guideline',
+  REGULATION: 'regulation'
+}
+
+/**
  * Process raw laws data into standardized format
  */
 function processLawsData(data, countryCode) {


### PR DESCRIPTION
… dynamic UI

Backend (law_manager.py):
- Add unified document schema with country/doc_type/grouping fields
- Add PDF storage management with local caching (pdfs/<country>/ directories)
- Add Merkblätter scrapers: AUVAScraper (AT), DGUVScraper (DE), ArboportaalScraper (NL)
- Add AI context awareness for country-specific terminology and legal citations
- Add PDF summarization feature for Merkblätter/PDF-only sources
- Add CLI command: merkblaetter --country AT/DE/NL --all --limit N
- Update scraper version to 8.0.0
- Add structure_labels config per country (Abschnitt/Buch/Hoofdstuk)

Frontend (LawBrowser.jsx):
- Add dynamic structure labels based on selected country/framework
- Display "Abschnitt" for AT/DE, "Hoofdstuk" for NL
- Add PDF download button in law header for sources with PDF
- Import and use getStructureLabel from euLawsDatabase

Database Service (euLawsDatabase.js):
- Export STRUCTURE_LABELS constant for AT/DE/NL
- Export getStructureLabel() function for dynamic label lookup
- Export DOC_TYPES enumeration (law, ordinance, merkblatt, guideline)