### PR TITLE
Fix broken PDF links and organize documents

### DIFF
--- a/src/components/modules/LawBrowser.jsx
+++ b/src/components/modules/LawBrowser.jsx
@@ -1255,6 +1255,10 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
   const { filteredLaws, pagination } = useMemo(() => {
     let results = allLaws
 
+    // Filter out category placeholder entries (e.g., _category_regulations, _category_manual_handling)
+    // These are internal organization entries, not real laws
+    results = results.filter(law => !law.abbreviation?.startsWith('_category_'))
+
     // Filter by category first
     if (selectedCategory !== 'all') {
       results = results.filter(law => law.type === selectedCategory)
@@ -1312,15 +1316,17 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
 
   // Separate laws into categories for display:
   // 1. Regular laws (text-based)
-  // 2. Merkblätter (AUVA M.plus, DGUV, TRBS, etc.) - includes all PDFs as badges
-  // Note: PDF availability is shown via badges, not as a separate section
-  const { regularLaws, merkblaetter } = useMemo(() => {
+  // 2. Merkblätter (AUVA M.plus, DGUV, TRBS, etc.) - supplementary documents
+  // 3. Law PDFs (PDF-only versions of regular laws like ASchG-PDF)
+  const { regularLaws, merkblaetter, lawPdfs } = useMemo(() => {
     const regular = []
     const supplements = []
+    const pdfs = []
 
     for (const law of filteredLaws) {
-      // Skip PDF variants (they're just PDF-only versions of regular laws)
+      // PDF variants go to separate "Law PDFs" category
       if (isPdfVariant(law)) {
+        pdfs.push(law)
         continue
       }
 
@@ -1334,7 +1340,7 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
       }
     }
 
-    return { regularLaws: regular, merkblaetter: supplements }
+    return { regularLaws: regular, merkblaetter: supplements, lawPdfs: pdfs }
   }, [filteredLaws])
 
   // Helper function to extract section title from text content when database title is incomplete
@@ -1976,10 +1982,10 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
                         <path d="M9 4.804A7.968 7.968 0 005.5 4c-1.255 0-2.443.29-3.5.804v10A7.969 7.969 0 015.5 14c1.669 0 3.218.51 4.5 1.385A7.962 7.962 0 0114.5 14c1.255 0 2.443.29 3.5.804v-10A7.968 7.968 0 0014.5 4c-1.255 0-2.443.29-3.5.804V12a1 1 0 11-2 0V4.804z" />
                       </svg>
                       <span className="font-semibold text-blue-700 dark:text-blue-300 text-sm">
-                        {framework === 'AT' ? 'AUVA Merkblätter & PDFs' :
-                         framework === 'DE' ? 'DGUV / Technical Rules & PDFs' :
-                         framework === 'NL' ? 'Arbocatalogi & PDFs' :
-                         'Merkblätter & PDFs'}
+                        {framework === 'AT' ? 'AUVA Merkblätter' :
+                         framework === 'DE' ? 'DGUV / Technische Regeln' :
+                         framework === 'NL' ? 'Arbocatalogi' :
+                         'Merkblätter'}
                       </span>
                       <span className="text-xs text-blue-500 dark:text-blue-400">({merkblaetter.length})</span>
                     </div>
@@ -2016,6 +2022,46 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
                           {law.metadata.description}
                         </p>
                       )}
+                    </button>
+                  ))}
+                </>
+              )}
+
+              {/* Law PDFs Section (red styling) - PDF-only versions of laws */}
+              {lawPdfs.length > 0 && (
+                <>
+                  <div className="px-3 py-2 bg-red-50 dark:bg-red-900/20 border-y border-red-100 dark:border-red-800 sticky top-0 z-10">
+                    <div className="flex items-center gap-2">
+                      <svg className="w-4 h-4 text-red-500" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clipRule="evenodd" />
+                      </svg>
+                      <span className="font-semibold text-red-700 dark:text-red-300 text-sm">
+                        Gesetzes-PDFs
+                      </span>
+                      <span className="text-xs text-red-500 dark:text-red-400">({lawPdfs.length})</span>
+                    </div>
+                  </div>
+                  {lawPdfs.map((law) => (
+                    <button
+                      key={law.id}
+                      onClick={() => openPdfModal(law)}
+                      className={`w-full text-left p-3 border-b border-gray-50 dark:border-whs-dark-800 transition-colors ${
+                        selectedLaw?.id === law.id
+                          ? 'bg-red-50 dark:bg-red-900/20 border-l-4 border-l-red-500'
+                          : 'hover:bg-gray-50 dark:hover:bg-whs-dark-800'
+                      }`}
+                    >
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="px-2 py-0.5 rounded text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300">
+                          {(law.abbreviation || law.abbr || 'PDF').replace(/-PDF$/i, '')}
+                        </span>
+                        <svg className="w-4 h-4 text-red-500" fill="currentColor" viewBox="0 0 20 20" title="PDF document">
+                          <path fillRule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clipRule="evenodd" />
+                        </svg>
+                      </div>
+                      <h4 className="font-medium text-gray-900 dark:text-white text-sm line-clamp-2">
+                        {(law.title_en || law.title || law.abbreviation || '').replace(/-PDF$/i, ' (PDF)')}
+                      </h4>
                     </button>
                   ))}
                 </>

--- a/src/services/euLawsDatabase.js
+++ b/src/services/euLawsDatabase.js
@@ -1184,8 +1184,10 @@ export function getPdfSourceUrl(law) {
   if (law.source?.local_pdf_path) {
     // Convert absolute path to relative URL for serving
     const path = law.source.local_pdf_path
+    // Handle both Windows backslashes and Unix forward slashes
+    const normalizedPath = path.replace(/\\/g, '/')
     // Extract just the filename or relative path portion
-    const match = path.match(/eu_safety_laws\/pdfs\/(.+)$/)
+    const match = normalizedPath.match(/eu_safety_laws\/pdfs\/(.+)$/)
     if (match) {
       return `/eu_safety_laws/pdfs/${match[1]}`
     }
@@ -1250,7 +1252,9 @@ export function hasLocalPdf(law) {
   // Method 1: Check for explicit local_pdf_path
   if (law.source?.local_pdf_path) {
     const path = law.source.local_pdf_path
-    const match = path.match(/eu_safety_laws\/pdfs\/(.+)$/)
+    // Handle both Windows backslashes and Unix forward slashes
+    const normalizedPath = path.replace(/\\/g, '/')
+    const match = normalizedPath.match(/eu_safety_laws\/pdfs\/(.+)$/)
     if (match) return true
   }
 
@@ -1278,7 +1282,9 @@ export function getLocalPdfUrl(law) {
   // Method 1: Check for explicit local_pdf_path
   if (law.source?.local_pdf_path) {
     const path = law.source.local_pdf_path
-    const match = path.match(/eu_safety_laws\/pdfs\/(.+)$/)
+    // Handle both Windows backslashes and Unix forward slashes
+    const normalizedPath = path.replace(/\\/g, '/')
+    const match = normalizedPath.match(/eu_safety_laws\/pdfs\/(.+)$/)
     if (match) {
       return `/eu_safety_laws/pdfs/${match[1]}`
     }


### PR DESCRIPTION
- Fix Windows backslash paths in PDF URL generation
- Filter out _category_* placeholder entries from law list
- Add separate "Gesetzes-PDFs" section for PDF variants
- Rename Merkblätter section without "& PDFs" suffix