### PR TITLE
Display PDFs in right column and localize site

### DIFF
--- a/src/components/ui/TypewriterText.jsx
+++ b/src/components/ui/TypewriterText.jsx
@@ -1,0 +1,170 @@
+import { useState, useEffect, useRef } from 'react'
+
+/**
+ * TypewriterText - Displays text with a smooth typewriter animation
+ * Used for showing translated content with a nice transition effect
+ */
+export function TypewriterText({
+  text,
+  speed = 15,
+  className = '',
+  onComplete,
+  startDelay = 0
+}) {
+  const [displayedText, setDisplayedText] = useState('')
+  const [isComplete, setIsComplete] = useState(false)
+  const [hasStarted, setHasStarted] = useState(false)
+  const indexRef = useRef(0)
+  const animationRef = useRef(null)
+
+  useEffect(() => {
+    // Reset when text changes
+    setDisplayedText('')
+    setIsComplete(false)
+    setHasStarted(false)
+    indexRef.current = 0
+
+    if (!text) return
+
+    // Start delay
+    const startTimer = setTimeout(() => {
+      setHasStarted(true)
+    }, startDelay)
+
+    return () => {
+      clearTimeout(startTimer)
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current)
+      }
+    }
+  }, [text, startDelay])
+
+  useEffect(() => {
+    if (!hasStarted || !text) return
+
+    let lastTime = 0
+    const msPerChar = speed
+
+    const animate = (timestamp) => {
+      if (!lastTime) lastTime = timestamp
+      const elapsed = timestamp - lastTime
+
+      if (elapsed >= msPerChar) {
+        lastTime = timestamp
+        indexRef.current++
+
+        if (indexRef.current <= text.length) {
+          setDisplayedText(text.slice(0, indexRef.current))
+          animationRef.current = requestAnimationFrame(animate)
+        } else {
+          setIsComplete(true)
+          if (onComplete) onComplete()
+        }
+      } else {
+        animationRef.current = requestAnimationFrame(animate)
+      }
+    }
+
+    animationRef.current = requestAnimationFrame(animate)
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current)
+      }
+    }
+  }, [hasStarted, text, speed, onComplete])
+
+  // Show cursor while typing
+  const cursor = !isComplete && hasStarted ? (
+    <span className="animate-pulse">|</span>
+  ) : null
+
+  return (
+    <span className={className}>
+      {displayedText}
+      {cursor}
+    </span>
+  )
+}
+
+/**
+ * TypewriterParagraph - Renders paragraphs with typewriter effect
+ * Handles multi-paragraph text properly
+ */
+export function TypewriterParagraph({
+  text,
+  speed = 10,
+  className = '',
+  paragraphClassName = '',
+  onComplete
+}) {
+  const paragraphs = text ? text.split('\n').filter(p => p.trim()) : []
+  const [completedParagraphs, setCompletedParagraphs] = useState(0)
+
+  useEffect(() => {
+    setCompletedParagraphs(0)
+  }, [text])
+
+  const handleParagraphComplete = (index) => {
+    if (index === paragraphs.length - 1 && onComplete) {
+      onComplete()
+    }
+    setCompletedParagraphs(prev => Math.max(prev, index + 1))
+  }
+
+  return (
+    <div className={className}>
+      {paragraphs.map((paragraph, index) => (
+        <p key={index} className={paragraphClassName}>
+          {index <= completedParagraphs ? (
+            <TypewriterText
+              text={paragraph}
+              speed={speed}
+              startDelay={index === 0 ? 0 : 50}
+              onComplete={() => handleParagraphComplete(index)}
+            />
+          ) : null}
+        </p>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * TransitionText - Smoothly transitions between original and translated text
+ * with a fade + typewriter effect
+ */
+export function TransitionText({
+  originalText,
+  translatedText,
+  showTranslation,
+  isTranslating,
+  className = ''
+}) {
+  if (isTranslating) {
+    return (
+      <div className={`${className} animate-pulse`}>
+        <div className="flex items-center gap-2 text-gray-500 dark:text-gray-400">
+          <div className="w-4 h-4 border-2 border-whs-orange-500 border-t-transparent rounded-full animate-spin"></div>
+          <span>Translating...</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (showTranslation && translatedText) {
+    return (
+      <div className={`${className} transition-opacity duration-300`}>
+        <TypewriterText text={translatedText} speed={8} />
+      </div>
+    )
+  }
+
+  return (
+    <div className={`${className} transition-opacity duration-300`}>
+      {originalText}
+    </div>
+  )
+}
+
+export default TypewriterText

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -11,6 +11,7 @@ export { FormattedAIResponse } from './FormattedAIResponse'
 export { RateLimitIndicator, useRateLimitStatus } from './RateLimitIndicator'
 export { SearchHistory } from './SearchHistory'
 export { PdfViewer, PdfSourceBadge, SupplementaryBadge } from './PdfViewer'
+export { TypewriterText, TypewriterParagraph, TransitionText } from './TypewriterText'
 
 // Re-export default components
 export { default as ButtonDefault } from './Button'

--- a/src/data/locales/de.json
+++ b/src/data/locales/de.json
@@ -52,7 +52,42 @@
     "compareAllCountries": "Diesen Abschnitt in allen 3 Ländern vergleichen",
     "compareTwoCountries": "Diesen Abschnitt mit einem anderen Land vergleichen",
     "filterBySection": "Nach Abschnitt-Nr./Titel filtern...",
-    "fullTextSearch": "Volltextsuche in diesem Gesetz..."
+    "fullTextSearch": "Volltextsuche in diesem Gesetz...",
+    "openNewTab": "In neuem Tab öffnen",
+    "selectLaw": "Gesetz auswählen",
+    "selectLawDescription": "Wählen Sie ein Gesetz aus der Liste, um den vollständigen Text mit Abschnittsnavigation zu lesen.",
+    "noContentAvailable": "Kein Inhalt verfügbar",
+    "noContentDescription": "Der vollständige Text für dieses Gesetz wurde nicht geladen.",
+    "viewOnOfficialSource": "Auf offizieller Quelle ansehen",
+    "relatedLaws": "Verwandte Gesetze",
+    "source": "Quelle",
+    "pdfDocument": "PDF-Dokument",
+    "htmlDocument": "HTML-Dokument",
+    "rateLimited": "Bitte warten",
+    "rateLimitedDescription": "KI-Anfragen sind ratenbegrenzt. Bitte warten Sie vor der nächsten Anfrage."
+  },
+  "lawBrowser": {
+    "lawsAndRegs": "Gesetze & Vorschriften",
+    "laws": "Gesetze",
+    "merkbl": "Merkbl.",
+    "lawPdfs": "Gesetzes-PDFs",
+    "searchLaws": "Gesetze durchsuchen...",
+    "auvaMerkblaetter": "AUVA Merkblätter",
+    "dguvRules": "DGUV / Technische Regeln",
+    "arbocatalogi": "Arbocatalogi"
+  },
+  "translation": {
+    "translateTo": "Übersetzen nach",
+    "translating": "Übersetze...",
+    "showOriginal": "Original anzeigen",
+    "showTranslation": "Übersetzung anzeigen",
+    "translationEnabled": "Übersetzung aktiviert",
+    "translationDisabled": "Übersetzung deaktiviert",
+    "selectLanguage": "Zielsprache wählen",
+    "german": "Deutsch",
+    "dutch": "Niederländisch",
+    "english": "Englisch",
+    "translateLaw": "Gesetz übersetzen"
   },
   "complexity": {
     "reading": "Ansicht:",

--- a/src/data/locales/en.json
+++ b/src/data/locales/en.json
@@ -52,7 +52,42 @@
     "compareAllCountries": "Compare this section across all 3 countries",
     "compareTwoCountries": "Compare this section with another country",
     "filterBySection": "Filter by section number/title...",
-    "fullTextSearch": "Full text search in this law..."
+    "fullTextSearch": "Full text search in this law...",
+    "openNewTab": "Open in new tab",
+    "selectLaw": "Select a Law",
+    "selectLawDescription": "Choose a law from the list to read its full content with section navigation.",
+    "noContentAvailable": "No content available",
+    "noContentDescription": "The full text for this law has not been loaded.",
+    "viewOnOfficialSource": "View on official source",
+    "relatedLaws": "Related Laws",
+    "source": "Source",
+    "pdfDocument": "PDF Document",
+    "htmlDocument": "HTML Document",
+    "rateLimited": "Please wait",
+    "rateLimitedDescription": "AI requests are rate limited. Please wait before making another request."
+  },
+  "lawBrowser": {
+    "lawsAndRegs": "Laws & Regulations",
+    "laws": "laws",
+    "merkbl": "Merkbl.",
+    "lawPdfs": "Law PDFs",
+    "searchLaws": "Search laws...",
+    "auvaMerkblaetter": "AUVA Merkblätter",
+    "dguvRules": "DGUV / Technical Rules",
+    "arbocatalogi": "Arbocatalogi"
+  },
+  "translation": {
+    "translateTo": "Translate to",
+    "translating": "Translating...",
+    "showOriginal": "Show Original",
+    "showTranslation": "Show Translation",
+    "translationEnabled": "Translation enabled",
+    "translationDisabled": "Translation disabled",
+    "selectLanguage": "Select target language",
+    "german": "German",
+    "dutch": "Dutch",
+    "english": "English",
+    "translateLaw": "Translate Law"
   },
   "complexity": {
     "reading": "Reading:",

--- a/src/data/locales/nl.json
+++ b/src/data/locales/nl.json
@@ -52,7 +52,42 @@
     "compareAllCountries": "Dit artikel vergelijken in alle 3 landen",
     "compareTwoCountries": "Dit artikel vergelijken met een ander land",
     "filterBySection": "Filteren op artikel nr./titel...",
-    "fullTextSearch": "Zoeken in deze wet..."
+    "fullTextSearch": "Zoeken in deze wet...",
+    "openNewTab": "Openen in nieuw tabblad",
+    "selectLaw": "Selecteer een Wet",
+    "selectLawDescription": "Kies een wet uit de lijst om de volledige tekst met artikelnavigatie te lezen.",
+    "noContentAvailable": "Geen inhoud beschikbaar",
+    "noContentDescription": "De volledige tekst voor deze wet is niet geladen.",
+    "viewOnOfficialSource": "Bekijk op officiële bron",
+    "relatedLaws": "Gerelateerde Wetten",
+    "source": "Bron",
+    "pdfDocument": "PDF-document",
+    "htmlDocument": "HTML-document",
+    "rateLimited": "Even wachten",
+    "rateLimitedDescription": "AI-verzoeken zijn gelimiteerd. Wacht even voor het volgende verzoek."
+  },
+  "lawBrowser": {
+    "lawsAndRegs": "Wetten & Regels",
+    "laws": "wetten",
+    "merkbl": "Merkbl.",
+    "lawPdfs": "Wet PDFs",
+    "searchLaws": "Zoek wetten...",
+    "auvaMerkblaetter": "AUVA Merkblätter",
+    "dguvRules": "DGUV / Technische Regels",
+    "arbocatalogi": "Arbocatalogi"
+  },
+  "translation": {
+    "translateTo": "Vertalen naar",
+    "translating": "Vertalen...",
+    "showOriginal": "Origineel tonen",
+    "showTranslation": "Vertaling tonen",
+    "translationEnabled": "Vertaling ingeschakeld",
+    "translationDisabled": "Vertaling uitgeschakeld",
+    "selectLanguage": "Selecteer doeltaal",
+    "german": "Duits",
+    "dutch": "Nederlands",
+    "english": "Engels",
+    "translateLaw": "Wet vertalen"
   },
   "complexity": {
     "reading": "Weergave:",

--- a/src/hooks/useAI.js
+++ b/src/hooks/useAI.js
@@ -181,6 +181,26 @@ export function useAI() {
     }
   }, [framework, language])
 
+  // Feature: Translate law text to a different language
+  const translateLawText = useCallback(async (lawText, sourceLanguage, targetLanguage) => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const response = await aiService.translateLawText(lawText, sourceLanguage, targetLanguage, framework)
+      return response
+    } catch (err) {
+      setError(err.message)
+      throw err
+    } finally {
+      setIsLoading(false)
+    }
+  }, [framework])
+
+  // Get rate limit status
+  const getRateLimitStatus = useCallback(() => {
+    return aiService.getRateLimitStatus()
+  }, [])
+
   return {
     isLoading,
     error,
@@ -195,7 +215,9 @@ export function useAI() {
     simplifyForBothLevels,
     findEquivalentLaw,
     generateSemanticTags,
-    compareMultipleCountries
+    compareMultipleCountries,
+    translateLawText,
+    getRateLimitStatus
   }
 }
 


### PR DESCRIPTION
…p crosslinking

1. PDF/HTML Display in Right Column:
   - PDFs and HTML docs now display inline in right column iframe instead of modals
   - Added controls for open in new tab, download, and close
   - Merkblätter and PDF sections click opens inline viewer

2. Removed Pagination, Added Collapsible Sections:
   - Removed pagination in left column, now uses scrolling
   - AUVA Merkblätter and Gesetzes-PDFs sections collapse by default
   - Added chevron indicators for expandable sections

3. Full Localization:
   - Added lawBrowser translations (lawsAndRegs, laws, merkbl, lawPdfs)
   - Added translation feature keys (translateTo, translating, showOriginal, etc.)
   - Added common UI keys (openNewTab, selectLaw, rateLimited, etc.)
   - Updated all three locale files (en, de, nl)

4. Law Translation with Typewriter Effect:
   - Added translation toggle in law header (DE, NL, EN options)
   - Sections can be translated on-demand with AI
   - TypewriterText component shows smooth typing animation
   - Translation cached to avoid redundant API calls
   - Rate limit indicator prevents requests during cooldown

5. Deep Crosslinking to Laws:
   - Detects law references (§ 1 ASchG, Artikel 3 Arbowet, DGUV 123, etc.)
   - Makes references clickable with blue highlighting
   - Clicking navigates to specific law and section in law browser
   - Works across German, Austrian, and Dutch law references