### PR TITLE
Remove translation feature from law header

### DIFF
--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -11,7 +11,7 @@ export { FormattedAIResponse } from './FormattedAIResponse'
 export { RateLimitIndicator, useRateLimitStatus } from './RateLimitIndicator'
 export { SearchHistory } from './SearchHistory'
 export { PdfViewer, PdfSourceBadge, SupplementaryBadge } from './PdfViewer'
-export { TypewriterText, TypewriterParagraph, TransitionText } from './TypewriterText'
+export { TypewriterText, TypewriterParagraph, TransitionText, OverwriteText } from './TypewriterText'
 
 // Re-export default components
 export { default as ButtonDefault } from './Button'


### PR DESCRIPTION
- Remove translation feature from law header (per-section translation remains)
- Add OverwriteText component for cool typewriter-over-original effect
- Original text fades out while translated text types over it
- Use consistent font styling for all law text