### PR TITLE
Optimize build cache download process

### DIFF
--- a/src/components/modules/LawBrowser.jsx
+++ b/src/components/modules/LawBrowser.jsx
@@ -2274,7 +2274,7 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
                       )}
                     </button>
                   ))}
-                </>
+                </div>
               )}
 
               {/* Merkblätter / Supplements Section (blue styling) - Collapsible */}


### PR DESCRIPTION
Changed closing fragment </> to </div> to match the opening <div className="space-y-1"> tag in the Regular Laws Section, fixing the Vite build error.