### PR TITLE
fix: improve section paragraph titles in middle column

### DIFF
--- a/src/components/modules/LawBrowser.jsx
+++ b/src/components/modules/LawBrowser.jsx
@@ -2425,17 +2425,17 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
           <div className="w-64 flex-shrink-0">
             <Card className="h-full overflow-hidden bg-white/80 dark:bg-whs-dark-900/80 backdrop-blur-sm shadow-xl border-0 ring-1 ring-gray-200/50 dark:ring-whs-dark-700/50">
               <div className="p-4 border-b border-gray-100 dark:border-whs-dark-700 bg-gradient-to-br from-slate-50 via-white to-slate-50/50 dark:from-whs-dark-800 dark:via-whs-dark-800 dark:to-whs-dark-900">
-                <div className="flex items-center gap-3 mb-3">
-                  <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-whs-orange-500 to-amber-600 flex items-center justify-center shadow-lg shadow-whs-orange-500/25">
-                    <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div className="flex items-center gap-2 mb-3">
+                  <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center shadow-md shadow-indigo-500/20">
+                    <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
                     </svg>
                   </div>
                   <div className="flex-1">
-                    <h3 className="font-extrabold text-gray-900 dark:text-white text-base">
+                    <h3 className="font-bold text-gray-900 dark:text-white text-sm">
                       {t.sections?.title || 'Sections'}
                     </h3>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 font-medium">
+                    <p className="text-[11px] text-gray-500 dark:text-gray-400 font-medium">
                       {filteredSections.length} of {lawSections.length} sections
                     </p>
                   </div>
@@ -2460,7 +2460,7 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
                       <button
                         key={level}
                         onClick={() => setRelevanceFilter(level)}
-                        className={`px-3 py-1.5 text-xs font-bold rounded-lg transition-all ${
+                        className={`px-2.5 py-1 text-[11px] font-semibold rounded-lg transition-all ${
                           relevanceFilter === level
                             ? 'bg-gradient-to-r from-whs-orange-500 to-amber-500 text-white shadow-md shadow-whs-orange-500/20 ring-2 ring-whs-orange-300 dark:ring-whs-orange-700'
                             : `${levelColors[level]} hover:ring-2 ring-1`
@@ -2498,20 +2498,20 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
                         {/* Chapter Header - Modern collapsible style */}
                         <button
                           onClick={() => toggleChapter(chapterKey)}
-                          className={`w-full px-3 py-3 rounded-xl text-sm flex items-center gap-2.5 transition-all duration-200 sticky top-0 z-10 ${
+                          className={`w-full px-3 py-2.5 rounded-xl text-xs font-bold flex items-center gap-2 transition-all duration-200 sticky top-0 z-10 ${
                             isChapterExpanded
-                              ? 'bg-gradient-to-r from-whs-orange-100 to-amber-100/50 dark:from-whs-orange-900/40 dark:to-amber-900/30 text-whs-orange-800 dark:text-whs-orange-200 shadow-md ring-2 ring-whs-orange-300/50 dark:ring-whs-orange-700/50'
-                              : 'bg-gray-100/90 dark:bg-whs-dark-800/90 text-gray-700 dark:text-gray-200 hover:bg-gray-200/90 dark:hover:bg-whs-dark-700/90 ring-1 ring-gray-200 dark:ring-gray-700'
+                              ? 'bg-gradient-to-r from-indigo-100 to-purple-100/50 dark:from-indigo-900/40 dark:to-purple-900/30 text-indigo-800 dark:text-indigo-200 shadow-sm ring-1 ring-indigo-200/50 dark:ring-indigo-700/50'
+                              : 'bg-gray-100/80 dark:bg-whs-dark-800/80 text-gray-600 dark:text-gray-300 hover:bg-gray-200/80 dark:hover:bg-whs-dark-700/80'
                           }`}
                           title={chapterTitle}
                         >
-                          <div className={`w-6 h-6 rounded-lg flex items-center justify-center transition-all ${
+                          <div className={`w-5 h-5 rounded-md flex items-center justify-center transition-all ${
                             isChapterExpanded
-                              ? 'bg-gradient-to-br from-whs-orange-500 to-amber-600 text-white shadow-md'
+                              ? 'bg-indigo-500 text-white shadow-sm'
                               : 'bg-gray-300 dark:bg-gray-600 text-gray-600 dark:text-gray-300'
                           }`}>
                             <svg
-                              className={`w-3.5 h-3.5 transition-transform duration-200 ${isChapterExpanded ? 'rotate-90' : ''}`}
+                              className={`w-3 h-3 transition-transform duration-200 ${isChapterExpanded ? 'rotate-90' : ''}`}
                               fill="none"
                               stroke="currentColor"
                               viewBox="0 0 24 24"
@@ -2519,10 +2519,10 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 5l7 7-7 7" />
                             </svg>
                           </div>
-                          <span className="flex-1 text-left line-clamp-2 font-bold">{chapterTitle}</span>
-                          <span className={`px-2.5 py-1 rounded-lg text-[10px] font-bold ${
+                          <span className="flex-1 text-left line-clamp-2 font-semibold">{chapterTitle}</span>
+                          <span className={`px-2 py-0.5 rounded-md text-[10px] font-bold ${
                             isChapterExpanded
-                              ? 'bg-whs-orange-200/60 dark:bg-whs-orange-800/50 text-whs-orange-700 dark:text-whs-orange-300'
+                              ? 'bg-indigo-200/50 dark:bg-indigo-800/50 text-indigo-700 dark:text-indigo-300'
                               : 'bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400'
                           }`}>
                             {sections.length}
@@ -2531,7 +2531,7 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
 
                         {/* Sections within chapter - only shown when expanded */}
                         {isChapterExpanded && (
-                          <div className="mt-1.5 space-y-1 ml-2 pl-2 border-l-2 border-whs-orange-200 dark:border-whs-orange-800">
+                          <div className="mt-1 space-y-1 ml-2 pl-2 border-l-2 border-indigo-200 dark:border-indigo-800">
                             {sections.map((section) => {
                               const relevanceLevel = section.amazon_logistics_relevance?.level
                               const relevanceStyles = {
@@ -2566,11 +2566,11 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
                                   >
                                     <div className="flex items-center gap-2">
                                       {/* Relevance indicator dot */}
-                                      <span className={`w-2 h-2 rounded-full flex-shrink-0 ${relevanceIndicator[relevanceLevel] || relevanceIndicator.low}`}></span>
-                                      <span className={`font-bold ${
+                                      <span className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${relevanceIndicator[relevanceLevel] || relevanceIndicator.low}`}></span>
+                                      <span className={`text-sm font-extrabold ${
                                         activeSection === section.id
                                           ? 'text-whs-orange-600 dark:text-whs-orange-400'
-                                          : 'text-gray-700 dark:text-gray-300'
+                                          : 'text-gray-900 dark:text-white'
                                       }`}>{section.number}</span>
                                       {section.whs_topics && section.whs_topics.length > 0 && (
                                         <span className="text-sm ml-auto opacity-60">
@@ -2579,7 +2579,11 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, onNavigationC
                                       )}
                                     </div>
                                     {section.title && (
-                                      <div className="text-[11px] line-clamp-2 mt-1 text-gray-500 dark:text-gray-400 font-medium" title={section.title}>
+                                      <div className={`text-xs line-clamp-2 mt-1.5 font-semibold ${
+                                        activeSection === section.id
+                                          ? 'text-whs-orange-700 dark:text-whs-orange-300'
+                                          : 'text-gray-700 dark:text-gray-300'
+                                      }`} title={section.title}>
                                         {highlightText(section.title, searchInLaw)}
                                       </div>
                                     )}


### PR DESCRIPTION
- Make section numbers (§ 20, etc.) larger and font-extrabold
- Make section titles font-semibold with better color contrast
- Revert chapter header changes back to original indigo/purple style
- Keep WHS Summary formatting and Amazon→MEU branding changes