### PR TITLE
refactor: move TNO/STL to guidanceTitles and unify arbocatalogi dropdown

### DIFF
--- a/src/data/locales/de.json
+++ b/src/data/locales/de.json
@@ -442,14 +442,22 @@
       "Arbowet": { "nl": "Arbeidsomstandighedenwet", "en": "Working Conditions Act" },
       "Arbobesluit": { "nl": "Arbeidsomstandighedenbesluit", "en": "Working Conditions Decree" },
       "Arboregeling": { "nl": "Arbeidsomstandighedenregeling", "en": "Working Conditions Regulation" },
-      "BRZO": { "nl": "Besluit risico's zware ongevallen", "en": "Major Accidents Decree" },
-      "STL Arbocatalogus Onderhoudswerkplaats": { "nl": "STL Arbocatalogus Onderhoudswerkplaats", "en": "STL Maintenance Workshop Safety Catalog" },
-      "STL Arbocatalogus Transport Logistiek": { "nl": "STL Arbocatalogus Transport en Logistiek", "en": "STL Transport & Logistics Safety Catalog" },
-      "STL Arbocatalogus Verticaal Transport": { "nl": "STL Arbocatalogus Verticaal Transport", "en": "STL Vertical Transport Safety Catalog" },
-      "STL Arbocatalogus Warehouse": { "nl": "STL Arbocatalogus Warehouse/Distributiecentrum", "en": "STL Warehouse/Distribution Center Safety Catalog" },
-      "TNO Factsheet Fysieke Belasting 2023": { "nl": "TNO Factsheet Fysieke Arbeidsbelasting 2023", "en": "TNO Physical Workload Factsheet 2023" },
-      "TNO Preventie Beroepsziekten": { "nl": "TNO Preventie Beroepsziekten Fysieke Belasting", "en": "TNO Occupational Disease Prevention - Physical Load" },
-      "TNO Wegwijzer Fysieke Belasting": { "nl": "TNO Wegwijzer Fysieke Belasting", "en": "TNO Physical Workload Guide" }
+      "BRZO": { "nl": "Besluit risico's zware ongevallen", "en": "Major Accidents Decree" }
+    }
+  },
+  "guidanceTitles": {
+    "NL": {
+      "_arbocatalogi": {
+        "STL Arbocatalogus Onderhoudswerkplaats": { "nl": "STL Arbocatalogus Onderhoudswerkplaats", "en": "STL Maintenance Workshop Safety Catalog" },
+        "STL Arbocatalogus Transport Logistiek": { "nl": "STL Arbocatalogus Transport en Logistiek", "en": "STL Transport & Logistics Safety Catalog" },
+        "STL Arbocatalogus Verticaal Transport": { "nl": "STL Arbocatalogus Verticaal Transport", "en": "STL Vertical Transport Safety Catalog" },
+        "STL Arbocatalogus Warehouse": { "nl": "STL Arbocatalogus Warehouse/Distributiecentrum", "en": "STL Warehouse/Distribution Center Safety Catalog" }
+      },
+      "_tnoResearch": {
+        "TNO Factsheet Fysieke Belasting 2023": { "nl": "TNO Factsheet Fysieke Arbeidsbelasting 2023", "en": "TNO Physical Workload Factsheet 2023" },
+        "TNO Preventie Beroepsziekten": { "nl": "TNO Preventie Beroepsziekten Fysieke Belasting", "en": "TNO Occupational Disease Prevention - Physical Load" },
+        "TNO Wegwijzer Fysieke Belasting": { "nl": "TNO Wegwijzer Fysieke Belasting", "en": "TNO Physical Workload Guide" }
+      }
     }
   }
 }

--- a/src/data/locales/en.json
+++ b/src/data/locales/en.json
@@ -442,14 +442,22 @@
       "Arbowet": { "nl": "Arbeidsomstandighedenwet", "en": "Working Conditions Act" },
       "Arbobesluit": { "nl": "Arbeidsomstandighedenbesluit", "en": "Working Conditions Decree" },
       "Arboregeling": { "nl": "Arbeidsomstandighedenregeling", "en": "Working Conditions Regulation" },
-      "BRZO": { "nl": "Besluit risico's zware ongevallen", "en": "Major Accidents Decree" },
-      "STL Arbocatalogus Onderhoudswerkplaats": { "nl": "STL Arbocatalogus Onderhoudswerkplaats", "en": "STL Maintenance Workshop Safety Catalog" },
-      "STL Arbocatalogus Transport Logistiek": { "nl": "STL Arbocatalogus Transport en Logistiek", "en": "STL Transport & Logistics Safety Catalog" },
-      "STL Arbocatalogus Verticaal Transport": { "nl": "STL Arbocatalogus Verticaal Transport", "en": "STL Vertical Transport Safety Catalog" },
-      "STL Arbocatalogus Warehouse": { "nl": "STL Arbocatalogus Warehouse/Distributiecentrum", "en": "STL Warehouse/Distribution Center Safety Catalog" },
-      "TNO Factsheet Fysieke Belasting 2023": { "nl": "TNO Factsheet Fysieke Arbeidsbelasting 2023", "en": "TNO Physical Workload Factsheet 2023" },
-      "TNO Preventie Beroepsziekten": { "nl": "TNO Preventie Beroepsziekten Fysieke Belasting", "en": "TNO Occupational Disease Prevention - Physical Load" },
-      "TNO Wegwijzer Fysieke Belasting": { "nl": "TNO Wegwijzer Fysieke Belasting", "en": "TNO Physical Workload Guide" }
+      "BRZO": { "nl": "Besluit risico's zware ongevallen", "en": "Major Accidents Decree" }
+    }
+  },
+  "guidanceTitles": {
+    "NL": {
+      "_arbocatalogi": {
+        "STL Arbocatalogus Onderhoudswerkplaats": { "nl": "STL Arbocatalogus Onderhoudswerkplaats", "en": "STL Maintenance Workshop Safety Catalog" },
+        "STL Arbocatalogus Transport Logistiek": { "nl": "STL Arbocatalogus Transport en Logistiek", "en": "STL Transport & Logistics Safety Catalog" },
+        "STL Arbocatalogus Verticaal Transport": { "nl": "STL Arbocatalogus Verticaal Transport", "en": "STL Vertical Transport Safety Catalog" },
+        "STL Arbocatalogus Warehouse": { "nl": "STL Arbocatalogus Warehouse/Distributiecentrum", "en": "STL Warehouse/Distribution Center Safety Catalog" }
+      },
+      "_tnoResearch": {
+        "TNO Factsheet Fysieke Belasting 2023": { "nl": "TNO Factsheet Fysieke Arbeidsbelasting 2023", "en": "TNO Physical Workload Factsheet 2023" },
+        "TNO Preventie Beroepsziekten": { "nl": "TNO Preventie Beroepsziekten Fysieke Belasting", "en": "TNO Occupational Disease Prevention - Physical Load" },
+        "TNO Wegwijzer Fysieke Belasting": { "nl": "TNO Wegwijzer Fysieke Belasting", "en": "TNO Physical Workload Guide" }
+      }
     }
   }
 }

--- a/src/data/locales/nl.json
+++ b/src/data/locales/nl.json
@@ -442,14 +442,22 @@
       "Arbowet": { "nl": "Arbeidsomstandighedenwet", "en": "Working Conditions Act" },
       "Arbobesluit": { "nl": "Arbeidsomstandighedenbesluit", "en": "Working Conditions Decree" },
       "Arboregeling": { "nl": "Arbeidsomstandighedenregeling", "en": "Working Conditions Regulation" },
-      "BRZO": { "nl": "Besluit risico's zware ongevallen", "en": "Major Accidents Decree" },
-      "STL Arbocatalogus Onderhoudswerkplaats": { "nl": "STL Arbocatalogus Onderhoudswerkplaats", "en": "STL Maintenance Workshop Safety Catalog" },
-      "STL Arbocatalogus Transport Logistiek": { "nl": "STL Arbocatalogus Transport en Logistiek", "en": "STL Transport & Logistics Safety Catalog" },
-      "STL Arbocatalogus Verticaal Transport": { "nl": "STL Arbocatalogus Verticaal Transport", "en": "STL Vertical Transport Safety Catalog" },
-      "STL Arbocatalogus Warehouse": { "nl": "STL Arbocatalogus Warehouse/Distributiecentrum", "en": "STL Warehouse/Distribution Center Safety Catalog" },
-      "TNO Factsheet Fysieke Belasting 2023": { "nl": "TNO Factsheet Fysieke Arbeidsbelasting 2023", "en": "TNO Physical Workload Factsheet 2023" },
-      "TNO Preventie Beroepsziekten": { "nl": "TNO Preventie Beroepsziekten Fysieke Belasting", "en": "TNO Occupational Disease Prevention - Physical Load" },
-      "TNO Wegwijzer Fysieke Belasting": { "nl": "TNO Wegwijzer Fysieke Belasting", "en": "TNO Physical Workload Guide" }
+      "BRZO": { "nl": "Besluit risico's zware ongevallen", "en": "Major Accidents Decree" }
+    }
+  },
+  "guidanceTitles": {
+    "NL": {
+      "_arbocatalogi": {
+        "STL Arbocatalogus Onderhoudswerkplaats": { "nl": "STL Arbocatalogus Onderhoudswerkplaats", "en": "STL Maintenance Workshop Safety Catalog" },
+        "STL Arbocatalogus Transport Logistiek": { "nl": "STL Arbocatalogus Transport en Logistiek", "en": "STL Transport & Logistics Safety Catalog" },
+        "STL Arbocatalogus Verticaal Transport": { "nl": "STL Arbocatalogus Verticaal Transport", "en": "STL Vertical Transport Safety Catalog" },
+        "STL Arbocatalogus Warehouse": { "nl": "STL Arbocatalogus Warehouse/Distributiecentrum", "en": "STL Warehouse/Distribution Center Safety Catalog" }
+      },
+      "_tnoResearch": {
+        "TNO Factsheet Fysieke Belasting 2023": { "nl": "TNO Factsheet Fysieke Arbeidsbelasting 2023", "en": "TNO Physical Workload Factsheet 2023" },
+        "TNO Preventie Beroepsziekten": { "nl": "TNO Preventie Beroepsziekten Fysieke Belasting", "en": "TNO Occupational Disease Prevention - Physical Load" },
+        "TNO Wegwijzer Fysieke Belasting": { "nl": "TNO Wegwijzer Fysieke Belasting", "en": "TNO Physical Workload Guide" }
+      }
     }
   }
 }

--- a/src/services/euLawsDatabase.js
+++ b/src/services/euLawsDatabase.js
@@ -1393,15 +1393,19 @@ export function isSupplementarySource(law) {
     return true
   }
 
-  // NL: PGS (Publicatiereeks Gevaarlijke Stoffen) and AI publications
-  if (abbrev.includes('pgs') || abbrev.startsWith('ai-')) {
+  // NL: PGS (Publicatiereeks Gevaarlijke Stoffen), AI publications, STL, TNO, RIVM
+  if (abbrev.includes('pgs') || abbrev.startsWith('ai-') ||
+      abbrev.includes('stl') || abbrev.includes('tno') || abbrev.includes('rivm') ||
+      abbrev.includes('nl arbeidsinspectie')) {
     return true
   }
 
   // Check title for supplementary indicators
   if (title.includes('merkblatt') || title.includes('technische regel') ||
       title.includes('technical rule') || title.includes('publicatiereeks') ||
-      title.includes('richtlijn') || title.includes('leitfaden')) {
+      title.includes('richtlijn') || title.includes('leitfaden') ||
+      title.includes('arbocatalogus') || title.includes('factsheet') ||
+      title.includes('wegwijzer')) {
     return true
   }
 
@@ -1436,6 +1440,10 @@ export function getSupplementarySourceType(law) {
   // NL
   if (abbrev.includes('pgs')) return 'pgs'
   if (abbrev.startsWith('ai-')) return 'ai'
+  if (abbrev.includes('stl')) return 'stl'
+  if (abbrev.includes('tno')) return 'tno'
+  if (abbrev.includes('rivm')) return 'rivm'
+  if (abbrev.includes('nl arbeidsinspectie')) return 'arbeidsinspectie'
 
   return 'default'
 }


### PR DESCRIPTION
- Moved TNO and STL documents from lawTitles.NL to new guidanceTitles section
- Categorized documents under _arbocatalogi (STL) and _tnoResearch (TNO)
- Updated isSupplementarySource() to recognize STL, TNO, RIVM, and NL Arbeidsinspectie
- Added getSupplementarySourceType() returns for stl, tno, rivm, arbeidsinspectie
- Added title-based detection for arbocatalogus, factsheet, wegwijzer
- This ensures all NL guidance documents appear in unified Arbocatalogi dropdown