### PR TITLE
Fix YAML syntax error in workflow file

### DIFF
--- a/.github/workflows/update-laws.yml
+++ b/.github/workflows/update-laws.yml
@@ -133,12 +133,11 @@ jobs:
 
           # Generate commit message with update summary
           CHANGES=$(cd eu_safety_laws && python law_manager.py status 2>/dev/null | head -20 || echo "Database updated")
+          UPDATE_DATE=$(date -u +'%Y-%m-%d')
 
-          git commit -m "chore: auto-update safety laws database
-
-Updates from scheduled check on $(date -u +'%Y-%m-%d')
-
-$CHANGES"
+          git commit -m "chore: auto-update safety laws database" \
+            -m "Updates from scheduled check on ${UPDATE_DATE}" \
+            -m "${CHANGES}"
 
           git push
 


### PR DESCRIPTION
Refactor multiline git commit message to use multiple -m flags instead of embedded newlines with command substitution, which caused YAML parsing errors on line 139.