### PR TITLE
Highlight search terms in law browser results

### DIFF
--- a/src/components/ui/InteractiveSearch.jsx
+++ b/src/components/ui/InteractiveSearch.jsx
@@ -192,12 +192,15 @@ export function InteractiveSearch({
 
   // Handle result selection
   const handleResultClick = useCallback((result) => {
+    // Capture search term before clearing it
+    const currentSearchTerm = searchTerm
     setIsOpen(false)
     setSearchTerm('')
     if (onSelectResult) {
-      onSelectResult(result)
+      // Pass the search term along with the result for highlighting
+      onSelectResult(result, currentSearchTerm)
     }
-  }, [onSelectResult])
+  }, [onSelectResult, searchTerm])
 
   // Handle suggestion click
   const handleSuggestionClick = useCallback((suggestion) => {

--- a/src/components/ui/SmartSearch.jsx
+++ b/src/components/ui/SmartSearch.jsx
@@ -309,9 +309,12 @@ export function SmartSearch({
 
   // Handle result click
   const handleResultClick = (doc) => {
+    // Capture search term before closing for highlighting
+    const currentSearchTerm = searchTerm
     setIsExpanded(false)
     if (onSelectLaw) {
-      onSelectLaw(doc)
+      // Pass the search term along with the doc for highlighting
+      onSelectLaw(doc, currentSearchTerm)
     }
   }
 


### PR DESCRIPTION
…Browser

When clicking on a search result from the main search:
- The search term is now passed to LawBrowser
- contentSearchTerm is set to highlight matches in the law content
- All sections containing the search term are automatically expanded
- Works with both pre-parsed chapters (from database) and fallback text parsing

This provides a better search experience by showing users exactly where their search terms appear in the law content.