### PR TITLE
Remove preview feature from sections

### DIFF
--- a/src/components/modules/LawBrowser.jsx
+++ b/src/components/modules/LawBrowser.jsx
@@ -1225,10 +1225,6 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, initialSectio
   const [wikiLoading, setWikiLoading] = useState(false)
   const [crosslinkPopup, setCrosslinkPopup] = useState({ open: false, term: null, data: null, x: 0, y: 0 })
 
-  // Paragraph hover preview state
-  const [paragraphPreview, setParagraphPreview] = useState({ open: false, section: null, x: 0, y: 0 })
-  const paragraphPreviewTimeoutRef = useRef(null)
-
   // Law reference hover preview state (for hovering over §4, Artikel 5, etc. in text)
   const [lawRefPreview, setLawRefPreview] = useState({ open: false, section: null, lawInfo: null, x: 0, y: 0 })
   const lawRefPreviewTimeoutRef = useRef(null)
@@ -1458,62 +1454,6 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, initialSectio
     document.addEventListener('click', handleClickOutside)
     return () => document.removeEventListener('click', handleClickOutside)
   }, [crosslinkPopup.open])
-
-  // Close paragraph preview when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (e) => {
-      if (paragraphPreview.open && !e.target.closest('.paragraph-preview-popup')) {
-        setParagraphPreview({ open: false, section: null, x: 0, y: 0 })
-      }
-    }
-    document.addEventListener('click', handleClickOutside)
-    return () => document.removeEventListener('click', handleClickOutside)
-  }, [paragraphPreview.open])
-
-  // Cleanup paragraph preview timeout on unmount
-  useEffect(() => {
-    return () => {
-      if (paragraphPreviewTimeoutRef.current) {
-        clearTimeout(paragraphPreviewTimeoutRef.current)
-      }
-    }
-  }, [])
-
-  // Handlers for paragraph hover preview
-  const handleParagraphMouseEnter = useCallback((e, section) => {
-    // Clear any pending timeout
-    if (paragraphPreviewTimeoutRef.current) {
-      clearTimeout(paragraphPreviewTimeoutRef.current)
-    }
-
-    // Capture rect synchronously before setTimeout (e.currentTarget is null inside setTimeout)
-    const target = e.currentTarget
-    if (!target) return
-    const rect = target.getBoundingClientRect()
-
-    // Set a delay before showing the preview to avoid flashing on quick mouse movements
-    paragraphPreviewTimeoutRef.current = setTimeout(() => {
-      setParagraphPreview({
-        open: true,
-        section,
-        x: rect.left + rect.width / 2,
-        y: rect.bottom + 8
-      })
-    }, 400) // 400ms delay before showing
-  }, [])
-
-  const handleParagraphMouseLeave = useCallback(() => {
-    // Clear the timeout if mouse leaves before preview shows
-    if (paragraphPreviewTimeoutRef.current) {
-      clearTimeout(paragraphPreviewTimeoutRef.current)
-      paragraphPreviewTimeoutRef.current = null
-    }
-    // Don't close immediately - allow moving to the popup
-  }, [])
-
-  const closeParagraphPreview = useCallback(() => {
-    setParagraphPreview({ open: false, section: null, x: 0, y: 0 })
-  }, [])
 
   // Close law reference preview when clicking outside
   useEffect(() => {
@@ -3599,8 +3539,6 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, initialSectio
                                     {/* Section Header with WHS Relevance - Clickable to expand/collapse */}
                                     <div
                                       className="flex items-start gap-2 mb-2 pb-2 border-b border-whs-orange-200 dark:border-whs-orange-800"
-                                      onMouseEnter={(e) => !expandedSections[section.id] && handleParagraphMouseEnter(e, section)}
-                                      onMouseLeave={handleParagraphMouseLeave}
                                     >
                                       <button
                                         onClick={() => toggleSection(section.id)}
@@ -4119,88 +4057,6 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, initialSectio
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
-          </div>
-        </div>
-      )}
-
-      {/* Paragraph Hover Preview Popup */}
-      {paragraphPreview.open && paragraphPreview.section && (
-        <div
-          className="paragraph-preview-popup fixed z-50 bg-white dark:bg-whs-dark-800 rounded-lg shadow-2xl border border-gray-200 dark:border-whs-dark-600 max-w-md max-h-80 overflow-hidden"
-          style={{
-            left: Math.min(Math.max(paragraphPreview.x, 220), window.innerWidth - 220),
-            top: Math.min(paragraphPreview.y, window.innerHeight - 340),
-            transform: 'translateX(-50%)'
-          }}
-          onMouseEnter={() => {
-            // Keep popup open when mouse enters the popup itself
-            if (paragraphPreviewTimeoutRef.current) {
-              clearTimeout(paragraphPreviewTimeoutRef.current)
-              paragraphPreviewTimeoutRef.current = null
-            }
-          }}
-          onMouseLeave={closeParagraphPreview}
-        >
-          {/* Header */}
-          <div className="flex items-center justify-between gap-2 p-3 bg-gradient-to-r from-whs-orange-500 to-whs-orange-600 text-white">
-            <div className="flex items-center gap-2 min-w-0">
-              <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-              <span className="font-bold text-sm">{paragraphPreview.section.number}</span>
-              {paragraphPreview.section.title && (
-                <span className="text-sm opacity-90 truncate">{paragraphPreview.section.title}</span>
-              )}
-            </div>
-            <button
-              onClick={closeParagraphPreview}
-              className="flex-shrink-0 p-1 hover:bg-white/20 rounded transition-colors"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-
-          {/* Content Preview */}
-          <div className="p-4 overflow-y-auto max-h-56">
-            {/* WHS Topics */}
-            {paragraphPreview.section.whs_topics && paragraphPreview.section.whs_topics.length > 0 && (
-              <div className="flex flex-wrap gap-1 mb-3">
-                {paragraphPreview.section.whs_topics.slice(0, 3).map(topic => (
-                  <span
-                    key={topic.id}
-                    className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-whs-orange-100 dark:bg-whs-orange-900/30 text-whs-orange-700 dark:text-whs-orange-300"
-                  >
-                    {WHS_TOPIC_LABELS[topic.id] || topic.id}
-                  </span>
-                ))}
-              </div>
-            )}
-
-            {/* Content excerpt */}
-            <div className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
-              {paragraphPreview.section.content ? (
-                <p className="line-clamp-6">
-                  {paragraphPreview.section.content.substring(0, 500)}
-                  {paragraphPreview.section.content.length > 500 && '...'}
-                </p>
-              ) : (
-                <p className="text-gray-400 dark:text-gray-500 italic">
-                  {t.lawBrowser?.noContentPreview || 'No content available'}
-                </p>
-              )}
-            </div>
-          </div>
-
-          {/* Footer - Click to expand hint */}
-          <div className="px-4 py-2 bg-gray-50 dark:bg-whs-dark-700 border-t border-gray-100 dark:border-whs-dark-600">
-            <p className="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
-              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122" />
-              </svg>
-              {t.lawBrowser?.clickToExpand || 'Click section header to expand full content'}
-            </p>
           </div>
         </div>
       )}


### PR DESCRIPTION
Remove the paragraph/section hover preview feature while retaining the law reference preview (§4, Artikel 5, etc.) functionality. The section preview was showing on hover over section headers in the sidebar, which was unnecessary UI complexity.