### PR TITLE
Fix law reference preview React error

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,6 +3,7 @@ import { useApp } from '../context/AppContext'
 import { HelpModal } from './HelpModal'
 import { useRateLimitStatus } from './ui/RateLimitIndicator'
 import { UnlockButton } from './ui/UnlockButton'
+import { clearLawUrl } from '../utils/lawUrl'
 
 // Framework configuration with colors
 const frameworks = {
@@ -180,6 +181,8 @@ export function Header() {
     // Save directly to localStorage before reload
     localStorage.setItem('whs_framework', newFramework)
     setShowFrameworkMenu(false)
+    // Clear URL law params to prevent old country from being restored after reload
+    clearLawUrl()
     // Reload to ensure all data is refreshed with new framework
     window.location.reload()
   }

--- a/src/components/modules/LawBrowser.jsx
+++ b/src/components/modules/LawBrowser.jsx
@@ -4110,7 +4110,7 @@ export function LawBrowser({ onBack, initialLawId, initialCountry, initialSectio
                     key={topic.id}
                     className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
                   >
-                    {WHS_TOPIC_LABELS[topic.id] || topic.id}
+                    {WHS_TOPIC_LABELS[topic.id]?.label || topic.id}
                   </span>
                 ))}
               </div>


### PR DESCRIPTION
- Fix React error #31 in law reference preview by accessing .label property of WHS_TOPIC_LABELS object instead of rendering the object directly
- Fix country change not updating by clearing URL params before reload, preventing the old country from being restored from URL after the framework switch