### PR TITLE
Debug automatic update trigger issue

### DIFF
--- a/.github/workflows/update-laws.yml
+++ b/.github/workflows/update-laws.yml
@@ -32,7 +32,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
The actions/setup-python cache: 'pip' option requires a requirements.txt or pyproject.toml file to exist. Since dependencies are installed inline, remove the cache option to fix the workflow error.