### PR TITLE
Add explicit permissions to update-laws workflow

### DIFF
--- a/.github/workflows/update-laws.yml
+++ b/.github/workflows/update-laws.yml
@@ -21,6 +21,9 @@ on:
 jobs:
   check-and-update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
Added explicit permission declarations to the `update-laws` GitHub Actions workflow to follow security best practices and ensure the workflow has the necessary permissions to perform its intended operations.

## Key Changes
- Added `permissions` block to the `check-and-update` job
- Granted `contents: write` permission to allow writing to repository contents
- Granted `issues: write` permission to allow creating or updating issues

## Implementation Details
These permissions are required for the workflow to:
- Commit and push changes to the repository (contents write)
- Create or update issues if needed as part of the update process (issues write)

By explicitly declaring permissions, we follow the principle of least privilege and improve the security posture of the workflow. This also makes the workflow's requirements transparent and easier to audit.

https://claude.ai/code/session_012y8gUbBY6wpreUpCk7bncf